### PR TITLE
Add UI login support and session endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from .models import ApiResponse, ResponseCode, FileInfo, TextShare
 from .auth import get_current_user, UserInfo
-from .rules import check_api_access
+from .rules import check_api_access, get_accessible_roots
 from .fs import (
     list_directory, create_directory, delete_file_or_directory,
     rename_file_or_directory, save_uploaded_file, open_file_for_download,
@@ -30,6 +30,24 @@ api_router = APIRouter(prefix="/api", tags=["api"])
 
 # Text shares storage (in-memory for simplicity)
 text_shares = {}
+
+
+# Session endpoints
+@api_router.get("/session")
+async def get_session(request: Request, user: UserInfo = Depends(get_current_user)):
+    """Return current session information"""
+
+    client_ip = get_client_ip(request)
+    roots = get_accessible_roots(user, client_ip)
+
+    return ApiResponse(
+        code=ResponseCode.SUCCESS.value,
+        msg="success",
+        data={
+            "user": {"name": user.name},
+            "roots": roots,
+        }
+    ).to_dict()
 
 
 # Request models

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,13 @@
         .drag-over { @apply border-blue-500 bg-blue-50; }
         .file-row:hover { @apply bg-gray-50; }
     </style>
+    <script>
+        window.__CHFS_INITIAL_STATE__ = {{ {
+            "authenticated": authenticated,
+            "user": user.name if user else "",
+            "accessible_roots": accessible_roots,
+        } | tojson }};
+    </script>
 </head>
 <body class="bg-gray-100 min-h-screen">
     <div x-data="fileManager()" x-cloak class="container mx-auto px-4 py-6 max-w-7xl">
@@ -21,36 +28,47 @@
                 <div>
                     <h1 class="text-2xl font-bold text-gray-900">{{ brand }}</h1>
                     <p class="text-gray-600 text-sm mt-1">
-                        {% if authenticated %}
-                            Welcome, {{ user.name }}
-                        {% else %}
-                            Please authenticate to access files
-                        {% endif %}
+                        <span x-show="isAuthenticated" x-cloak x-text="`Welcome, ${currentUser}`"></span>
+                        <span x-show="!isAuthenticated" x-cloak>Please authenticate to access files</span>
                     </p>
                 </div>
-                <div class="flex gap-3">
-                    {% if authenticated %}
-                        <button @click="showUpload = true" 
+                <div class="flex gap-3" x-cloak>
+                    <template x-if="isAuthenticated">
+                        <div class="flex gap-3">
+                            <button @click="showUpload = true"
+                                    class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                                <i class="fas fa-upload"></i>
+                                <span class="hidden sm:inline">Upload</span>
+                            </button>
+                            <button @click="showNewFolder = true"
+                                    class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                                <i class="fas fa-folder-plus"></i>
+                                <span class="hidden sm:inline">New Folder</span>
+                            </button>
+                            <button @click="showTextShare = true"
+                                    class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                                <i class="fas fa-share-alt"></i>
+                                <span class="hidden sm:inline">Share Text</span>
+                            </button>
+                            <button @click="logout()"
+                                    class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded-lg transition-colors">
+                                <i class="fas fa-sign-out-alt"></i>
+                                <span class="hidden sm:inline">Logout</span>
+                            </button>
+                        </div>
+                    </template>
+                    <template x-if="!isAuthenticated">
+                        <button @click="focusLogin()"
                                 class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
-                            <i class="fas fa-upload"></i>
-                            <span class="hidden sm:inline">Upload</span>
+                            <i class="fas fa-sign-in-alt"></i>
+                            <span class="hidden sm:inline">Log In</span>
                         </button>
-                        <button @click="showNewFolder = true" 
-                                class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
-                            <i class="fas fa-folder-plus"></i>
-                            <span class="hidden sm:inline">New Folder</span>
-                        </button>
-                        <button @click="showTextShare = true" 
-                                class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
-                            <i class="fas fa-share-alt"></i>
-                            <span class="hidden sm:inline">Share Text</span>
-                        </button>
-                    {% endif %}
+                    </template>
                 </div>
             </div>
         </header>
 
-        {% if not authenticated %}
+        <div x-show="!isAuthenticated" x-cloak>
             <!-- Login prompt -->
             <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 mb-6">
                 <div class="flex items-center gap-3">
@@ -61,27 +79,63 @@
                     </div>
                 </div>
             </div>
-        {% else %}
+
+            <!-- Login form -->
+            <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+                <form class="space-y-5" @submit.prevent="performLogin()">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-username">Username</label>
+                            <input id="login-username" x-ref="loginUsername" type="text" x-model="loginUsername" autocomplete="username"
+                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                   placeholder="Enter username" required>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-password">Password</label>
+                            <input id="login-password" type="password" x-model="loginPassword" autocomplete="current-password"
+                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                   placeholder="Enter password" required>
+                        </div>
+                    </div>
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                        <label class="inline-flex items-center gap-2 text-sm text-gray-600">
+                            <input type="checkbox" x-model="rememberCredentials" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                            Remember credentials on this device
+                        </label>
+                        <div class="flex items-center gap-3">
+                            <button type="submit"
+                                    class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">
+                                <span>Sign In</span>
+                            </button>
+                            <span class="text-xs text-gray-500 hidden sm:block">Default: admin / admin123</span>
+                        </div>
+                    </div>
+                    <p x-show="loginError" x-text="loginError" class="text-sm text-red-600"></p>
+                </form>
+            </div>
+        </div>
+
+        <div x-show="isAuthenticated" x-cloak>
             <!-- Share selector -->
             <div class="bg-white rounded-lg shadow-sm mb-6 p-4">
                 <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
                     <label class="font-medium text-gray-700">Share:</label>
-                    <select x-model="currentRoot" @change="loadFiles()" 
+                    <select x-model="currentRoot" @change="loadFiles()"
                             class="border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent">
                         <option value="">Select a share...</option>
-                        {% for root in accessible_roots %}
-                            <option value="{{ root }}">{{ root }}</option>
-                        {% endfor %}
+                        <template x-for="root in accessibleRoots" :key="root">
+                            <option :value="root" x-text="root"></option>
+                        </template>
                     </select>
-                    
+
                     <!-- Breadcrumb -->
-                    <div x-show="currentRoot" class="flex items-center gap-2 text-sm text-gray-600">
+                    <div x-show="currentRoot" class="flex items-center gap-2 text-sm text-gray-600" x-cloak>
                         <i class="fas fa-folder text-gray-400"></i>
                         <span x-text="currentRoot"></span>
                         <template x-for="(part, index) in pathParts" :key="index">
                             <span>
                                 <i class="fas fa-chevron-right text-gray-400 mx-1"></i>
-                                <a href="#" @click.prevent="navigateToPath(index)" 
+                                <a href="#" @click.prevent="navigateToPath(index)"
                                    class="hover:text-blue-600 transition-colors" x-text="part"></a>
                             </span>
                         </template>
@@ -94,15 +148,15 @@
                  @drop.prevent="handleDrop"
                  @dragover.prevent="$el.classList.add('drag-over')"
                  @dragleave.prevent="$el.classList.remove('drag-over')">
-                
+
                 <!-- Loading state -->
-                <div x-show="loading" class="p-8 text-center text-gray-500">
+                <div x-show="loading" class="p-8 text-center text-gray-500" x-cloak>
                     <i class="fas fa-spinner fa-spin text-2xl mb-2"></i>
                     <p>Loading files...</p>
                 </div>
 
                 <!-- Error state -->
-                <div x-show="error && !loading" class="p-8 text-center text-red-500">
+                <div x-show="error && !loading" class="p-8 text-center text-red-500" x-cloak>
                     <i class="fas fa-exclamation-triangle text-2xl mb-2"></i>
                     <p x-text="error"></p>
                     <button @click="loadFiles()" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">
@@ -111,14 +165,14 @@
                 </div>
 
                 <!-- File table -->
-                <div x-show="!loading && !error && files.length > 0">
+                <div x-show="!loading && !error && files.length > 0" x-cloak>
                     <!-- Toolbar -->
                     <div class="border-b border-gray-200 p-4 bg-gray-50 flex justify-between items-center">
                         <div class="flex items-center gap-4">
                             <span class="text-sm text-gray-600" x-text="`${files.length} items`"></span>
-                            <div x-show="selectedFiles.length > 0" class="text-sm text-blue-600">
+                            <div x-show="selectedFiles.length > 0" class="text-sm text-blue-600" x-cloak>
                                 <span x-text="`${selectedFiles.length} selected`"></span>
-                                <button @click="deleteSelected()" 
+                                <button @click="deleteSelected()"
                                         class="ml-3 text-red-600 hover:text-red-700 font-medium">
                                     <i class="fas fa-trash"></i> Delete
                                 </button>
@@ -135,7 +189,7 @@
                             <thead class="bg-gray-50 border-b border-gray-200">
                                 <tr class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     <th class="px-4 py-3 w-8">
-                                        <input type="checkbox" @change="toggleSelectAll()" 
+                                        <input type="checkbox" @change="toggleSelectAll()"
                                                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
                                     </th>
                                     <th class="px-4 py-3">Name</th>
@@ -146,10 +200,10 @@
                             </thead>
                             <tbody class="divide-y divide-gray-200">
                                 <!-- Parent directory -->
-                                <tr x-show="currentPath !== ''" class="file-row hover:bg-gray-50 transition-colors">
+                                <tr x-show="currentPath !== ''" class="file-row hover:bg-gray-50 transition-colors" x-cloak>
                                     <td class="px-4 py-3"></td>
                                     <td class="px-4 py-3">
-                                        <a href="#" @click.prevent="navigateUp()" 
+                                        <a href="#" @click.prevent="navigateUp()"
                                            class="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors">
                                             <i class="fas fa-level-up-alt text-gray-400"></i>
                                             <span>..</span>
@@ -164,7 +218,7 @@
                                 <template x-for="file in files" :key="file.path">
                                     <tr class="file-row hover:bg-gray-50 transition-colors">
                                         <td class="px-4 py-3">
-                                            <input type="checkbox" 
+                                            <input type="checkbox"
                                                    :value="file.path"
                                                    x-model="selectedFiles"
                                                    class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
@@ -172,24 +226,24 @@
                                         <td class="px-4 py-3">
                                             <div class="flex items-center gap-2">
                                                 <i :class="file.is_dir ? 'fas fa-folder text-yellow-500' : 'fas fa-file text-gray-400'"></i>
-                                                <a href="#" 
-                                                   @click.prevent="file.is_dir ? navigateToFolder(file.path) : downloadFile(file.path)"
+                                                <a href="#"
+                                                   @click.prevent="file.is_dir ? navigateToFolder(file.path) : downloadFile(file)"
                                                    class="text-blue-600 hover:text-blue-800 transition-colors font-medium"
                                                    x-text="file.name"></a>
                                             </div>
                                         </td>
-                                        <td class="px-4 py-3 hidden md:table-cell text-sm text-gray-600" 
+                                        <td class="px-4 py-3 hidden md:table-cell text-sm text-gray-600"
                                             x-text="file.is_dir ? '-' : formatFileSize(file.size)"></td>
-                                        <td class="px-4 py-3 hidden lg:table-cell text-sm text-gray-600" 
+                                        <td class="px-4 py-3 hidden lg:table-cell text-sm text-gray-600"
                                             x-text="formatDate(file.modified)"></td>
                                         <td class="px-4 py-3">
                                             <div class="flex gap-1">
-                                                <button @click="renameFile(file)" 
+                                                <button @click="renameFile(file)"
                                                         class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
                                                         title="Rename">
                                                     <i class="fas fa-edit"></i>
                                                 </button>
-                                                <button @click="deleteFile(file.path)" 
+                                                <button @click="deleteFile(file.path)"
                                                         class="p-1 text-gray-400 hover:text-red-600 transition-colors"
                                                         title="Delete">
                                                     <i class="fas fa-trash"></i>
@@ -204,13 +258,13 @@
                 </div>
 
                 <!-- Empty state -->
-                <div x-show="!loading && !error && files.length === 0 && currentRoot" class="p-8 text-center text-gray-500">
+                <div x-show="!loading && !error && files.length === 0 && currentRoot" class="p-8 text-center text-gray-500" x-cloak>
                     <i class="fas fa-folder-open text-4xl mb-4 text-gray-300"></i>
                     <p class="text-lg font-medium mb-2">This folder is empty</p>
                     <p class="text-sm">Upload files or create folders to get started</p>
                 </div>
             </div>
-        {% endif %}
+        </div>
 
         <!-- Upload Modal -->
         <div x-show="showUpload" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -324,21 +378,35 @@
 
     <script>
         function fileManager() {
+            const initial = window.__CHFS_INITIAL_STATE__ || {};
+            const initialRoots = Array.isArray(initial.accessible_roots) ? initial.accessible_roots : [];
+            const initialUser = initial.user || '';
+
             return {
-                // State
-                currentRoot: '',
+                // Session state
+                isAuthenticated: Boolean(initial.authenticated),
+                currentUser: initialUser,
+                accessibleRoots: initialRoots,
+                authHeader: '',
+                loginUsername: initialUser,
+                loginPassword: '',
+                rememberCredentials: true,
+                loginError: '',
+
+                // File browser state
+                currentRoot: initialRoots.length > 0 ? initialRoots[0] : '',
                 currentPath: '',
                 files: [],
                 selectedFiles: [],
                 loading: false,
                 error: null,
-                
+
                 // Modals
                 showUpload: false,
                 showNewFolder: false,
                 showTextShare: false,
                 showRename: false,
-                
+
                 // Form data
                 uploadFiles: [],
                 newFolderName: '',
@@ -348,26 +416,268 @@
                 renameTarget: null,
                 uploading: false,
 
+                init() {
+                    const savedUser = localStorage.getItem('chfsAuthUser');
+                    if (!this.loginUsername && savedUser) {
+                        this.loginUsername = savedUser;
+                    }
+
+                    this.tryAutoLogin().then((autoLoggedIn) => {
+                        if (!autoLoggedIn && this.isAuthenticated && this.currentRoot) {
+                            this.loadFiles();
+                        }
+                    });
+                },
+
                 // Computed
                 get pathParts() {
                     return this.currentPath ? this.currentPath.split('/').filter(p => p) : [];
                 },
 
-                // Methods
+                buildHeaders(additional = {}) {
+                    const headers = { ...additional };
+                    if (this.authHeader) {
+                        headers['Authorization'] = this.authHeader;
+                    }
+                    return headers;
+                },
+
+                createAuthHeader(username, password) {
+                    return 'Basic ' + btoa(`${username}:${password}`);
+                },
+
+                clearStoredCredentials() {
+                    localStorage.removeItem('chfsAuthHeader');
+                    localStorage.removeItem('chfsAuthUser');
+                },
+
+                resetCredentials() {
+                    this.authHeader = '';
+                    this.clearStoredCredentials();
+                },
+
+                focusLogin() {
+                    this.$nextTick(() => {
+                        if (this.$refs.loginUsername) {
+                            this.$refs.loginUsername.focus();
+                        }
+                    });
+                },
+
+                async tryAutoLogin() {
+                    const savedHeader = localStorage.getItem('chfsAuthHeader');
+                    const savedUser = localStorage.getItem('chfsAuthUser');
+
+                    if (savedUser && !this.loginUsername) {
+                        this.loginUsername = savedUser;
+                    }
+
+                    if (savedHeader) {
+                        this.authHeader = savedHeader;
+                        this.rememberCredentials = true;
+                        const success = await this.refreshSession(false);
+                        if (success) {
+                            if (this.currentRoot) {
+                                await this.loadFiles();
+                            }
+                            return true;
+                        }
+                        this.resetCredentials();
+                    }
+
+                    if (!this.isAuthenticated) {
+                        this.focusLogin();
+                    }
+
+                    return false;
+                },
+
+                ensureAuthenticated(showMessage = true) {
+                    if (this.isAuthenticated || this.authHeader) {
+                        return true;
+                    }
+                    if (showMessage) {
+                        this.loginError = 'Please log in to continue.';
+                        this.focusLogin();
+                    }
+                    return false;
+                },
+
+                parseApiResponse(data) {
+                    if (data && typeof data === 'object' && 'detail' in data) {
+                        return data.detail;
+                    }
+                    return data;
+                },
+
+                async refreshSession(showErrors = true) {
+                    if (!this.authHeader) {
+                        return false;
+                    }
+
+                    try {
+                        const response = await fetch('/api/session', {
+                            headers: this.buildHeaders()
+                        });
+
+                        if (response.status === 401) {
+                            if (showErrors) {
+                                this.loginError = 'Invalid username or password.';
+                            }
+                            this.handleUnauthorized(null);
+                            return false;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
+                            this.isAuthenticated = true;
+                            this.loginError = '';
+                            this.currentUser = payload.data?.user?.name || this.loginUsername;
+                            if (!this.loginUsername) {
+                                this.loginUsername = this.currentUser;
+                            }
+
+                            const roots = Array.isArray(payload.data?.roots) ? payload.data.roots : [];
+                            this.accessibleRoots = roots;
+                            if (!this.currentRoot || !roots.includes(this.currentRoot)) {
+                                this.currentRoot = roots[0] || '';
+                                this.currentPath = '';
+                            }
+                            return true;
+                        }
+
+                        if (showErrors) {
+                            this.loginError = payload.msg || 'Failed to verify credentials.';
+                        }
+                        return false;
+                    } catch (e) {
+                        if (showErrors) {
+                            this.loginError = 'Login failed: ' + e.message;
+                        }
+                        return false;
+                    }
+                },
+
+                async performLogin() {
+                    const username = (this.loginUsername || '').trim();
+                    if (!username || !this.loginPassword) {
+                        this.loginError = 'Please enter username and password.';
+                        this.focusLogin();
+                        return;
+                    }
+
+                    try {
+                        this.loginUsername = username;
+                        this.authHeader = this.createAuthHeader(username, this.loginPassword);
+                    } catch (e) {
+                        this.loginError = 'Failed to encode credentials.';
+                        return;
+                    }
+
+                    const success = await this.refreshSession(true);
+                    if (success) {
+                        this.error = null;
+                        this.loginPassword = '';
+
+                        if (this.rememberCredentials) {
+                            localStorage.setItem('chfsAuthHeader', this.authHeader);
+                            localStorage.setItem('chfsAuthUser', this.currentUser);
+                        } else {
+                            this.clearStoredCredentials();
+                        }
+
+                        if (this.currentRoot) {
+                            await this.loadFiles();
+                        } else {
+                            this.files = [];
+                            this.selectedFiles = [];
+                        }
+                    } else {
+                        this.resetCredentials();
+                    }
+                },
+
+                handleUnauthorized(message = 'Session expired. Please log in again.') {
+                    this.isAuthenticated = false;
+                    this.accessibleRoots = [];
+                    this.files = [];
+                    this.currentRoot = '';
+                    this.currentPath = '';
+                    this.selectedFiles = [];
+                    this.showUpload = false;
+                    this.showNewFolder = false;
+                    this.showTextShare = false;
+                    this.showRename = false;
+                    this.uploadFiles = [];
+                    this.uploading = false;
+                    this.shareText = '';
+                    this.shareUrl = '';
+                    this.renameTarget = null;
+                    this.renameValue = '';
+
+                    if (message !== null) {
+                        this.error = message;
+                        this.loginError = message;
+                    }
+
+                    this.resetCredentials();
+                    this.focusLogin();
+                },
+
+                logout() {
+                    this.isAuthenticated = false;
+                    this.accessibleRoots = [];
+                    this.files = [];
+                    this.currentRoot = '';
+                    this.currentPath = '';
+                    this.selectedFiles = [];
+                    this.error = null;
+                    this.loginError = '';
+                    this.loginPassword = '';
+                    this.showUpload = false;
+                    this.showNewFolder = false;
+                    this.showTextShare = false;
+                    this.showRename = false;
+                    this.uploadFiles = [];
+                    this.uploading = false;
+                    this.shareText = '';
+                    this.shareUrl = '';
+                    this.renameTarget = null;
+                    this.renameValue = '';
+                    this.resetCredentials();
+                    this.focusLogin();
+                },
+
                 async loadFiles() {
-                    if (!this.currentRoot) return;
-                    
+                    if (!this.currentRoot) {
+                        this.files = [];
+                        this.selectedFiles = [];
+                        return;
+                    }
+
+                    if (!this.ensureAuthenticated(false)) {
+                        return;
+                    }
+
                     this.loading = true;
                     this.error = null;
-                    
+
                     try {
-                        const response = await fetch(`/api/list?root=${encodeURIComponent(this.currentRoot)}&path=${encodeURIComponent(this.currentPath)}`);
-                        const data = await response.json();
-                        
-                        if (data.code === 0) {
-                            this.files = data.data.files;
+                        const response = await fetch(`/api/list?root=${encodeURIComponent(this.currentRoot)}&path=${encodeURIComponent(this.currentPath)}`, {
+                            headers: this.buildHeaders()
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
+                            this.files = payload.data?.files || [];
+                            this.selectedFiles = [];
                         } else {
-                            this.error = data.msg;
+                            this.error = payload.msg || 'Failed to load files.';
                         }
                     } catch (e) {
                         this.error = 'Failed to load files: ' + e.message;
@@ -397,29 +707,74 @@
                     this.loadFiles();
                 },
 
-                downloadFile(path) {
-                    const url = `/api/download?root=${encodeURIComponent(this.currentRoot)}&path=${encodeURIComponent(path)}`;
-                    window.open(url, '_blank');
+                async downloadFile(file) {
+                    if (!file || !file.path) return;
+                    if (!this.ensureAuthenticated(false)) return;
+
+                    try {
+                        const response = await fetch(`/api/download?root=${encodeURIComponent(this.currentRoot)}&path=${encodeURIComponent(file.path)}`, {
+                            headers: this.buildHeaders()
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        if (!response.ok) {
+                            throw new Error('Download failed with status ' + response.status);
+                        }
+
+                        const blob = await response.blob();
+                        let filename = file.name || file.path.split('/').pop() || 'download';
+                        const disposition = response.headers.get('content-disposition');
+                        if (disposition) {
+                            const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+                            const asciiMatch = disposition.match(/filename="?([^";]+)"?/i);
+                            if (utfMatch) {
+                                filename = decodeURIComponent(utfMatch[1]);
+                            } else if (asciiMatch) {
+                                filename = asciiMatch[1];
+                            }
+                        }
+
+                        const url = URL.createObjectURL(blob);
+                        const link = document.createElement('a');
+                        link.href = url;
+                        link.download = filename;
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                        URL.revokeObjectURL(url);
+                    } catch (e) {
+                        alert('Download failed: ' + e.message);
+                    }
                 },
 
                 async deleteFile(path) {
+                    if (!this.ensureAuthenticated()) return;
                     if (!confirm('Are you sure you want to delete this item?')) return;
-                    
+
                     try {
                         const response = await fetch('/api/delete', {
                             method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
+                            headers: this.buildHeaders({'Content-Type': 'application/json'}),
                             body: JSON.stringify({
                                 root: this.currentRoot,
                                 paths: [path]
                             })
                         });
-                        
-                        const data = await response.json();
-                        if (data.code === 0) {
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
                             this.loadFiles();
                         } else {
-                            alert('Delete failed: ' + data.msg);
+                            alert('Delete failed: ' + (payload.msg || 'Unknown error'));
                         }
                     } catch (e) {
                         alert('Delete failed: ' + e.message);
@@ -427,25 +782,31 @@
                 },
 
                 async deleteSelected() {
+                    if (!this.ensureAuthenticated()) return;
                     if (this.selectedFiles.length === 0) return;
                     if (!confirm(`Delete ${this.selectedFiles.length} selected items?`)) return;
-                    
+
                     try {
                         const response = await fetch('/api/delete', {
                             method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
+                            headers: this.buildHeaders({'Content-Type': 'application/json'}),
                             body: JSON.stringify({
                                 root: this.currentRoot,
                                 paths: this.selectedFiles
                             })
                         });
-                        
-                        const data = await response.json();
-                        if (data.code === 0) {
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
                             this.selectedFiles = [];
                             this.loadFiles();
                         } else {
-                            alert('Delete failed: ' + data.msg);
+                            alert('Delete failed: ' + (payload.msg || 'Unknown error'));
                         }
                     } catch (e) {
                         alert('Delete failed: ' + e.message);
@@ -454,30 +815,38 @@
 
                 renameFile(file) {
                     this.renameTarget = file;
-                    this.renameValue = file.name;
+                    this.renameValue = file?.name || '';
                     this.showRename = true;
                 },
 
                 async confirmRename() {
+                    if (!this.ensureAuthenticated()) return;
                     if (!this.renameTarget || !this.renameValue.trim()) return;
-                    
+
                     try {
                         const response = await fetch('/api/rename', {
                             method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
+                            headers: this.buildHeaders({'Content-Type': 'application/json'}),
                             body: JSON.stringify({
                                 root: this.currentRoot,
                                 path: this.renameTarget.path,
                                 newName: this.renameValue.trim()
                             })
                         });
-                        
-                        const data = await response.json();
-                        if (data.code === 0) {
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
                             this.showRename = false;
+                            this.renameTarget = null;
+                            this.renameValue = '';
                             this.loadFiles();
                         } else {
-                            alert('Rename failed: ' + data.msg);
+                            alert('Rename failed: ' + (payload.msg || 'Unknown error'));
                         }
                     } catch (e) {
                         alert('Rename failed: ' + e.message);
@@ -485,25 +854,31 @@
                 },
 
                 async createFolder() {
+                    if (!this.ensureAuthenticated()) return;
                     if (!this.newFolderName.trim()) return;
-                    
+
                     try {
                         const response = await fetch('/api/mkdir', {
                             method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
+                            headers: this.buildHeaders({'Content-Type': 'application/json'}),
                             body: JSON.stringify({
                                 root: this.currentRoot,
                                 path: this.currentPath ? `${this.currentPath}/${this.newFolderName}` : this.newFolderName
                             })
                         });
-                        
-                        const data = await response.json();
-                        if (data.code === 0) {
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
                             this.showNewFolder = false;
                             this.newFolderName = '';
                             this.loadFiles();
                         } else {
-                            alert('Create folder failed: ' + data.msg);
+                            alert('Create folder failed: ' + (payload.msg || 'Unknown error'));
                         }
                     } catch (e) {
                         alert('Create folder failed: ' + e.message);
@@ -526,32 +901,39 @@
                 },
 
                 async uploadSelectedFiles() {
+                    if (!this.ensureAuthenticated()) return;
                     if (this.uploadFiles.length === 0) return;
-                    
+
                     this.uploading = true;
-                    
+
                     try {
                         for (const file of this.uploadFiles) {
                             const formData = new FormData();
                             formData.append('root', this.currentRoot);
                             formData.append('path', this.currentPath);
                             formData.append('file', file);
-                            
+
                             const response = await fetch('/api/upload', {
                                 method: 'POST',
+                                headers: this.buildHeaders(),
                                 body: formData
                             });
-                            
-                            const data = await response.json();
-                            if (data.code !== 0) {
-                                alert(`Upload failed for ${file.name}: ${data.msg}`);
+
+                            if (response.status === 401) {
+                                this.handleUnauthorized();
+                                return;
+                            }
+
+                            const payload = this.parseApiResponse(await response.json());
+                            if (payload.code !== 0) {
+                                alert(`Upload failed for ${file.name}: ${payload.msg || 'Unknown error'}`);
                             }
                         }
-                        
+
                         this.showUpload = false;
                         this.uploadFiles = [];
                         this.loadFiles();
-                        
+
                     } catch (e) {
                         alert('Upload failed: ' + e.message);
                     } finally {
@@ -560,20 +942,26 @@
                 },
 
                 async createTextShare() {
+                    if (!this.ensureAuthenticated()) return;
                     if (!this.shareText.trim()) return;
-                    
+
                     try {
                         const response = await fetch('/api/textshare', {
                             method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify({text: this.shareText})
+                            headers: this.buildHeaders({'Content-Type': 'application/json'}),
+                            body: JSON.stringify({ text: this.shareText })
                         });
-                        
-                        const data = await response.json();
-                        if (data.code === 0) {
-                            this.shareUrl = window.location.origin + data.data.url;
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
+                            this.shareUrl = window.location.origin + payload.data.url;
                         } else {
-                            alert('Text share failed: ' + data.msg);
+                            alert('Text share failed: ' + (payload.msg || 'Unknown error'));
                         }
                     } catch (e) {
                         alert('Text share failed: ' + e.message);
@@ -599,18 +987,19 @@
                 },
 
                 formatFileSize(bytes) {
-                    if (bytes === 0) return '0 B';
+                    if (!bytes) return '0 B';
                     const k = 1024;
-                    const sizes = ['B', 'KB', 'MB', 'GB'];
+                    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
                     const i = Math.floor(Math.log(bytes) / Math.log(k));
                     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
                 },
 
                 formatDate(timestamp) {
-                    return new Date(timestamp * 1000).toLocaleDateString() + ' ' + 
-                           new Date(timestamp * 1000).toLocaleTimeString();
+                    if (!timestamp) return '';
+                    const date = new Date(timestamp * 1000);
+                    return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
                 }
-            }
+            };
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a `/api/session` endpoint to expose the authenticated user and their accessible shares
- implement a login form and client-side session handling so the UI can supply Basic Auth headers and remember credentials when desired
- update file operations in the UI to reuse the stored credentials and gracefully handle expired sessions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5dcb22b648327b0c262152cbcd330