### PR TITLE
Add dynamic user registration support

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -11,7 +11,7 @@ from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
 
 from .models import ApiResponse, ResponseCode, FileInfo, TextShare
-from .auth import get_current_user, UserInfo
+from .auth import get_current_user, UserInfo, hash_password
 from .rules import check_api_access, get_accessible_roots
 from .fs import (
     list_directory, create_directory, delete_file_or_directory,
@@ -20,8 +20,9 @@ from .fs import (
 )
 from .utils import parse_http_range, generate_short_id, create_response_headers
 from .metrics import upload_context, download_context
-from .config import get_config
+from .config import get_config, get_user_by_name
 from .ipfilter import get_client_ip
+from .user_store import add_registered_user
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,104 @@ async def get_session(request: Request, user: UserInfo = Depends(get_current_use
     ).to_dict()
 
 
+@api_router.post("/register")
+async def register_user(register_req: RegisterRequest):
+    """Register a new user account."""
+
+    username = register_req.username.strip()
+    password = register_req.password
+    confirm = register_req.confirmPassword
+
+    if not username:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                code=ResponseCode.ERROR.value,
+                msg="Username is required",
+                data=None,
+            ).to_dict(),
+        )
+
+    if len(username) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                code=ResponseCode.ERROR.value,
+                msg="Username must be at least 3 characters",
+                data=None,
+            ).to_dict(),
+        )
+
+    if not password or len(password) < 6:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                code=ResponseCode.ERROR.value,
+                msg="Password must be at least 6 characters",
+                data=None,
+            ).to_dict(),
+        )
+
+    if password != confirm:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                code=ResponseCode.ERROR.value,
+                msg="Passwords do not match",
+                data=None,
+            ).to_dict(),
+        )
+
+    if get_user_by_name(username):
+        raise HTTPException(
+            status_code=409,
+            detail=ApiResponse(
+                code=ResponseCode.CONFLICT.value,
+                msg="Username already exists",
+                data=None,
+            ).to_dict(),
+        )
+
+    config = get_config()
+    default_roots = [share.name for share in config.shares] or []
+
+    try:
+        hashed = hash_password(password)
+        new_user, new_rules = add_registered_user(username, hashed, default_roots)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=ApiResponse(
+                code=ResponseCode.CONFLICT.value,
+                msg=str(exc),
+                data=None,
+            ).to_dict(),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to register user: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail=ApiResponse(
+                code=ResponseCode.INTERNAL_ERROR.value,
+                msg="Failed to register user",
+                data=None,
+            ).to_dict(),
+        ) from exc
+
+    # Update in-memory config so the new user can log in immediately
+    config.users.append(new_user)
+    config.rules.extend(new_rules)
+
+    return ApiResponse(
+        code=ResponseCode.SUCCESS.value,
+        msg="Registration successful",
+        data={
+            "user": {"name": username},
+            "roots": default_roots,
+        },
+    ).to_dict()
+
+
 # Request models
 class MkdirRequest(BaseModel):
     root: str
@@ -69,6 +168,12 @@ class DeleteRequest(BaseModel):
 
 class TextShareRequest(BaseModel):
     text: str
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+    confirmPassword: str
 
 
 @api_router.get("/list")

--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ from .models import (
     TlsConfig, LoggingConfig, RateLimitConfig, IpFilterConfig,
     UiConfig, DavConfig, HotReloadConfig
 )
+from .user_store import load_registered_entries
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,13 @@ class ConfigManager:
                 data = yaml.safe_load(f) or {}
             
             config = self._parse_config(data)
+
+            # Merge dynamically registered users and their rules
+            dynamic_users, dynamic_rules = load_registered_entries()
+            if dynamic_users:
+                config.users.extend(dynamic_users)
+            if dynamic_rules:
+                config.rules.extend(dynamic_rules)
             self.config = config
             logger.info(f"Configuration loaded from {self.config_path}")
             return config

--- a/app/user_store.py
+++ b/app/user_store.py
@@ -1,0 +1,151 @@
+"""Utility module for managing dynamically registered users."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .models import Permission, RuleInfo, UserInfo
+
+logger = logging.getLogger(__name__)
+
+STORE_PATH = Path("data/users.json")
+
+
+def _default_store() -> Dict[str, List[Dict]]:
+    """Return the default empty store structure."""
+    return {"users": []}
+
+
+def _load_store() -> Dict[str, List[Dict]]:
+    """Load the dynamic user store from disk."""
+    try:
+        if not STORE_PATH.exists():
+            return _default_store()
+
+        with STORE_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            logger.warning("Invalid user store structure; resetting store")
+            return _default_store()
+
+        data.setdefault("users", [])
+        if not isinstance(data["users"], list):
+            logger.warning("Invalid users list in store; resetting store")
+            data["users"] = []
+        return data
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to parse user store JSON: %s", exc)
+        return _default_store()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Unexpected error loading user store: %s", exc)
+        return _default_store()
+
+
+def _atomic_write(data: Dict[str, List[Dict]]):
+    """Write store data atomically to disk."""
+    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = STORE_PATH.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    tmp_path.replace(STORE_PATH)
+
+
+def load_registered_entries() -> Tuple[List[UserInfo], List[RuleInfo]]:
+    """Load registered users and their rules from the dynamic store."""
+    store = _load_store()
+    users: List[UserInfo] = []
+    rules: List[RuleInfo] = []
+
+    for entry in store.get("users", []):
+        try:
+            name = entry.get("name")
+            pass_hash = entry.get("pass_hash")
+            is_bcrypt = entry.get("is_bcrypt", True)
+            if not name or not pass_hash:
+                continue
+
+            users.append(UserInfo(name=name, pass_hash=pass_hash, is_bcrypt=is_bcrypt))
+
+            for rule_data in entry.get("rules", []):
+                try:
+                    allow_values = rule_data.get("allow", [Permission.READ.value])
+                    allow = [Permission(value) for value in allow_values]
+                except ValueError:
+                    logger.warning("Invalid permission in rule for user %s", name)
+                    allow = [Permission.READ]
+
+                rule = RuleInfo(
+                    who=name,
+                    allow=allow,
+                    roots=rule_data.get("roots", []),
+                    paths=rule_data.get("paths", ["/"]),
+                    ip_allow=rule_data.get("ip_allow", ["*"]),
+                    ip_deny=rule_data.get("ip_deny", []),
+                )
+                rules.append(rule)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to load user entry: %s", exc)
+            continue
+
+    return users, rules
+
+
+def add_registered_user(
+    username: str,
+    pass_hash: str,
+    roots: List[str],
+    *,
+    permissions: List[Permission] | None = None,
+    paths: List[str] | None = None,
+    ip_allow: List[str] | None = None,
+    ip_deny: List[str] | None = None,
+) -> Tuple[UserInfo, List[RuleInfo]]:
+    """Add a new registered user to the dynamic store.
+
+    Returns the created user info and associated rules.
+    """
+
+    store = _load_store()
+    username_lower = username.lower()
+    for entry in store.get("users", []):
+        if str(entry.get("name", "")).lower() == username_lower:
+            raise ValueError("User already exists")
+
+    permissions = permissions or [Permission.READ, Permission.WRITE, Permission.DELETE]
+    paths = paths or ["/"]
+    ip_allow = ip_allow or ["*"]
+    ip_deny = ip_deny or []
+
+    user_entry = {
+        "name": username,
+        "pass_hash": pass_hash,
+        "is_bcrypt": True,
+        "rules": [
+            {
+                "allow": [perm.value for perm in permissions],
+                "roots": roots,
+                "paths": paths,
+                "ip_allow": ip_allow,
+                "ip_deny": ip_deny,
+            }
+        ],
+    }
+
+    store.setdefault("users", []).append(user_entry)
+    _atomic_write(store)
+
+    user = UserInfo(name=username, pass_hash=pass_hash, is_bcrypt=True)
+    rule = RuleInfo(
+        who=username,
+        allow=list(permissions),
+        roots=roots,
+        paths=paths,
+        ip_allow=ip_allow,
+        ip_deny=ip_deny,
+    )
+
+    return user, [rule]

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,43 +75,91 @@
                     <i class="fas fa-lock text-yellow-600"></i>
                     <div>
                         <h3 class="font-semibold text-yellow-800">Authentication Required</h3>
-                        <p class="text-yellow-700 text-sm mt-1">Please provide credentials to access the file server.</p>
+                        <p class="text-yellow-700 text-sm mt-1">
+                            Please sign in to continue or create an account below.
+                        </p>
                     </div>
                 </div>
             </div>
 
-            <!-- Login form -->
+            <!-- Login / Register forms -->
             <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-                <form class="space-y-5" @submit.prevent="performLogin()">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-username">Username</label>
-                            <input id="login-username" x-ref="loginUsername" type="text" x-model="loginUsername" autocomplete="username"
-                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                   placeholder="Enter username" required>
+                <template x-if="!showRegister">
+                    <form class="space-y-5" @submit.prevent="performLogin()">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="login-username">Username</label>
+                                <input id="login-username" x-ref="loginUsername" type="text" x-model="loginUsername" autocomplete="username"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Enter username" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="login-password">Password</label>
+                                <input id="login-password" type="password" x-model="loginPassword" autocomplete="current-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Enter password" required>
+                            </div>
                         </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-password">Password</label>
-                            <input id="login-password" type="password" x-model="loginPassword" autocomplete="current-password"
-                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                   placeholder="Enter password" required>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <label class="inline-flex items-center gap-2 text-sm text-gray-600">
+                                <input type="checkbox" x-model="rememberCredentials" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                Remember credentials on this device
+                            </label>
+                            <div class="flex items-center gap-3">
+                                <button type="submit"
+                                        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">
+                                    <span>Sign In</span>
+                                </button>
+                                <span class="text-xs text-gray-500 hidden sm:block">Default: admin / admin123</span>
+                            </div>
                         </div>
-                    </div>
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                        <label class="inline-flex items-center gap-2 text-sm text-gray-600">
-                            <input type="checkbox" x-model="rememberCredentials" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-                            Remember credentials on this device
-                        </label>
-                        <div class="flex items-center gap-3">
-                            <button type="submit"
-                                    class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">
-                                <span>Sign In</span>
+                        <p x-show="loginInfo" x-text="loginInfo" class="text-sm text-green-600"></p>
+                        <p x-show="loginError" x-text="loginError" class="text-sm text-red-600"></p>
+                        <p class="text-sm text-gray-600">
+                            Don't have an account?
+                            <button type="button" @click="switchToRegister()"
+                                    class="text-blue-600 hover:text-blue-700 font-medium">
+                                Create one now
                             </button>
-                            <span class="text-xs text-gray-500 hidden sm:block">Default: admin / admin123</span>
+                        </p>
+                    </form>
+                </template>
+
+                <template x-if="showRegister">
+                    <form class="space-y-5" @submit.prevent="performRegister()">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-username">Username</label>
+                                <input id="register-username" x-ref="registerUsername" type="text" x-model="registerUsername" autocomplete="username"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Choose a username" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-password">Password</label>
+                                <input id="register-password" type="password" x-model="registerPassword" autocomplete="new-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="At least 6 characters" required>
+                            </div>
+                            <div class="md:col-span-2">
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-confirm">Confirm Password</label>
+                                <input id="register-confirm" type="password" x-model="registerConfirm" autocomplete="new-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Re-enter password" required>
+                            </div>
                         </div>
-                    </div>
-                    <p x-show="loginError" x-text="loginError" class="text-sm text-red-600"></p>
-                </form>
+                        <p x-show="registerError" x-text="registerError" class="text-sm text-red-600"></p>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <button type="button" @click="switchToLogin()"
+                                    class="text-sm text-gray-600 hover:text-gray-800">
+                                Back to sign in
+                            </button>
+                            <button type="submit"
+                                    class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors">
+                                Create Account
+                            </button>
+                        </div>
+                    </form>
+                </template>
             </div>
         </div>
 
@@ -392,6 +440,12 @@
                 loginPassword: '',
                 rememberCredentials: true,
                 loginError: '',
+                loginInfo: '',
+                showRegister: false,
+                registerUsername: '',
+                registerPassword: '',
+                registerConfirm: '',
+                registerError: '',
 
                 // File browser state
                 currentRoot: initialRoots.length > 0 ? initialRoots[0] : '',
@@ -464,6 +518,80 @@
                     });
                 },
 
+                switchToRegister() {
+                    this.showRegister = true;
+                    this.registerUsername = this.loginUsername || '';
+                    this.registerPassword = '';
+                    this.registerConfirm = '';
+                    this.registerError = '';
+                    this.loginError = '';
+                    this.loginInfo = '';
+                    this.$nextTick(() => {
+                        if (this.$refs.registerUsername) {
+                            this.$refs.registerUsername.focus();
+                        }
+                    });
+                },
+
+                switchToLogin(message = '') {
+                    this.showRegister = false;
+                    this.registerUsername = '';
+                    this.registerPassword = '';
+                    this.registerConfirm = '';
+                    this.registerError = '';
+                    if (message) {
+                        this.loginInfo = message;
+                        this.loginError = '';
+                    } else {
+                        this.loginInfo = '';
+                    }
+                    this.$nextTick(() => this.focusLogin());
+                },
+
+                async performRegister() {
+                    const username = (this.registerUsername || '').trim();
+                    this.registerError = '';
+                    this.loginInfo = '';
+                    if (!username || username.length < 3) {
+                        this.registerError = 'Username must be at least 3 characters.';
+                        return;
+                    }
+
+                    if (!this.registerPassword || this.registerPassword.length < 6) {
+                        this.registerError = 'Password must be at least 6 characters.';
+                        return;
+                    }
+
+                    if (this.registerPassword !== this.registerConfirm) {
+                        this.registerError = 'Passwords do not match.';
+                        return;
+                    }
+
+                    try {
+                        const response = await fetch('/api/register', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                username,
+                                password: this.registerPassword,
+                                confirmPassword: this.registerConfirm,
+                            }),
+                        });
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            this.registerError = '';
+                            this.loginUsername = username;
+                            this.loginPassword = '';
+                            this.switchToLogin('Registration successful! Please sign in.');
+                        } else {
+                            this.registerError = payload?.msg || 'Registration failed.';
+                        }
+                    } catch (e) {
+                        this.registerError = 'Registration failed: ' + e.message;
+                    }
+                },
+
                 async tryAutoLogin() {
                     const savedHeader = localStorage.getItem('chfsAuthHeader');
                     const savedUser = localStorage.getItem('chfsAuthUser');
@@ -498,6 +626,7 @@
                     }
                     if (showMessage) {
                         this.loginError = 'Please log in to continue.';
+                        this.loginInfo = '';
                         this.focusLogin();
                     }
                     return false;
@@ -520,18 +649,20 @@
                             headers: this.buildHeaders()
                         });
 
-                        if (response.status === 401) {
-                            if (showErrors) {
-                                this.loginError = 'Invalid username or password.';
-                            }
-                            this.handleUnauthorized(null);
-                            return false;
+                    if (response.status === 401) {
+                        if (showErrors) {
+                            this.loginError = 'Invalid username or password.';
+                            this.loginInfo = '';
                         }
+                        this.handleUnauthorized(null);
+                        return false;
+                    }
 
                         const payload = this.parseApiResponse(await response.json());
                         if (payload.code === 0) {
                             this.isAuthenticated = true;
                             this.loginError = '';
+                            this.loginInfo = '';
                             this.currentUser = payload.data?.user?.name || this.loginUsername;
                             if (!this.loginUsername) {
                                 this.loginUsername = this.currentUser;
@@ -548,11 +679,13 @@
 
                         if (showErrors) {
                             this.loginError = payload.msg || 'Failed to verify credentials.';
+                            this.loginInfo = '';
                         }
                         return false;
                     } catch (e) {
                         if (showErrors) {
                             this.loginError = 'Login failed: ' + e.message;
+                            this.loginInfo = '';
                         }
                         return false;
                     }
@@ -562,8 +695,9 @@
                     const username = (this.loginUsername || '').trim();
                     if (!username || !this.loginPassword) {
                         this.loginError = 'Please enter username and password.';
+                        this.loginInfo = '';
                         this.focusLogin();
-                        return;
+                        return false;
                     }
 
                     try {
@@ -571,13 +705,16 @@
                         this.authHeader = this.createAuthHeader(username, this.loginPassword);
                     } catch (e) {
                         this.loginError = 'Failed to encode credentials.';
-                        return;
+                        this.loginInfo = '';
+                        return false;
                     }
 
                     const success = await this.refreshSession(true);
                     if (success) {
                         this.error = null;
                         this.loginPassword = '';
+                        this.loginError = '';
+                        this.loginInfo = '';
 
                         if (this.rememberCredentials) {
                             localStorage.setItem('chfsAuthHeader', this.authHeader);
@@ -595,6 +732,7 @@
                     } else {
                         this.resetCredentials();
                     }
+                    return success;
                 },
 
                 handleUnauthorized(message = 'Session expired. Please log in again.') {
@@ -618,6 +756,7 @@
                     if (message !== null) {
                         this.error = message;
                         this.loginError = message;
+                        this.loginInfo = '';
                     }
 
                     this.resetCredentials();


### PR DESCRIPTION
## Summary
- add a persistent user store that merges registered accounts into the running configuration
- expose a `/api/register` endpoint that validates input, hashes credentials, and grants access to configured shares
- enhance the SPA login experience with a registration form and messaging hooks for the new workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d5e12b64b48327a0ed7571399686b4