### PR TITLE
Remove upload limit and centralize server operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py File Server"
   textShareDir: "C:\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB
+  # maxUploadSize: 104857600  # 可选，取消注释可限制上传大小
 
 # WebDAV 配置
 dav:
@@ -217,7 +217,7 @@ dav:
 - IP 地址过滤（CIDR 支持）
 
 ### 文件上传
-- 可配置文件大小限制
+- 默认不限制上传大小，可按需设置 `maxUploadSize`
 - 安全的文件名处理
 - 防止恶意文件上传
 

--- a/app/fs.py
+++ b/app/fs.py
@@ -335,7 +335,7 @@ async def save_uploaded_file(
     rel_path: str,
     filename: str,
     upload_file: UploadFile,
-    max_size: int = 100 * 1024 * 1024  # 100MB default
+    max_size: Optional[int] = None,
 ) -> int:
     """
     Save uploaded file safely
@@ -345,7 +345,7 @@ async def save_uploaded_file(
         rel_path: Relative directory path
         filename: Target filename
         upload_file: FastAPI UploadFile object
-        max_size: Maximum file size in bytes
+        max_size: Optional maximum file size in bytes
         
     Returns:
         Number of bytes written
@@ -392,7 +392,7 @@ async def save_uploaded_file(
                     break
                 
                 bytes_written += len(chunk)
-                if bytes_written > max_size:
+                if max_size is not None and bytes_written > max_size:
                     # Clean up partial file
                     await aiofiles.os.remove(file_path)
                     raise FileSystemError(f"File too large (max: {max_size} bytes)")

--- a/app/models.py
+++ b/app/models.py
@@ -143,7 +143,7 @@ class UiConfig:
     brand: str = "chfs-py"
     title: str = "chfs-py File Server"
     textShareDir: str = ""
-    maxUploadSize: int = 104857600  # 100MB
+    maxUploadSize: Optional[int] = None  # None means no enforced limit
     language: str = "en"
 
 

--- a/app/server_runtime.py
+++ b/app/server_runtime.py
@@ -1,0 +1,124 @@
+"""Server-side runtime helpers consolidating storage operations."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import AsyncGenerator, Callable, List, Optional, Tuple
+
+from fastapi import UploadFile
+
+from .auth import hash_password
+from .config import get_config, get_user_by_name
+from .fs import (
+    FileSystemError,
+    PathTraversalError,
+    create_directory,
+    delete_file_or_directory,
+    list_directory,
+    open_file_for_download,
+    rename_file_or_directory,
+    save_uploaded_file,
+    write_text_file,
+)
+from .models import Config, FileInfo, HttpRange, UserInfo
+from .user_store import add_registered_user
+
+logger = logging.getLogger(__name__)
+
+
+class FileServer:
+    """High-level facade for server-side storage actions."""
+
+    def __init__(self, config_provider: Callable[[], Config] = get_config):
+        self._config_provider = config_provider
+
+    @property
+    def config(self) -> Config:
+        """Return the latest loaded configuration."""
+        return self._config_provider()
+
+    def _default_roots(self) -> List[str]:
+        return [share.name for share in self.config.shares]
+
+    async def list_directory(self, root: str, path: str) -> List[FileInfo]:
+        return await list_directory(root, path)
+
+    async def upload_file(self, root: str, path: str, upload: UploadFile) -> int:
+        filename = upload.filename or "unnamed"
+        return await save_uploaded_file(
+            root,
+            path,
+            filename,
+            upload,
+            max_size=self.config.ui.maxUploadSize,
+        )
+
+    async def create_directory(self, root: str, path: str) -> None:
+        await create_directory(root, path)
+
+    async def delete_path(self, root: str, path: str) -> None:
+        await delete_file_or_directory(root, path)
+
+    async def rename_path(self, root: str, path: str, new_name: str) -> None:
+        await rename_file_or_directory(root, path, new_name)
+
+    async def open_for_download(
+        self,
+        root: str,
+        path: str,
+        http_range: Optional[HttpRange],
+    ) -> Tuple[AsyncGenerator[bytes, None], int, int, int]:
+        return await open_file_for_download(root, path, http_range)
+
+    async def write_text(self, root: str, rel_path: str, content: str) -> int:
+        return await write_text_file(root, rel_path, content)
+
+    async def save_text_share(self, share_id: str, text: str) -> Optional[str]:
+        """Persist a text share to disk when configured."""
+        config = self.config
+        if not config.ui.textShareDir:
+            return None
+
+        text_dir_path = Path(config.ui.textShareDir).resolve()
+
+        for share in config.shares:
+            try:
+                relative = text_dir_path.relative_to(share.path)
+            except ValueError:
+                continue
+
+            target_rel = f"{relative}/{share_id}.txt".strip("/")
+            await write_text_file(share.name, target_rel, text)
+            logger.info("Saved text share %s to %s:%s", share_id, share.name, target_rel)
+            return f"{share.name}:{target_rel}"
+
+        logger.warning("Text share directory %s is not within any share", text_dir_path)
+        return None
+
+    def register_user(self, username: str, password: str) -> Tuple[UserInfo, List[str]]:
+        """Register a new user and persist credentials."""
+        if get_user_by_name(username):
+            raise ValueError("Username already exists")
+
+        default_roots = self._default_roots()
+        hashed = hash_password(password)
+
+        user, rules = add_registered_user(username, hashed, default_roots)
+
+        config = self.config
+        config.users.append(user)
+        config.rules.extend(rules)
+
+        logger.info("Registered new user %s with roots %s", username, default_roots)
+        return user, default_roots
+
+
+file_server = FileServer()
+
+__all__ = [
+    "FileServer",
+    "file_server",
+    "FileSystemError",
+    "PathTraversalError",
+]

--- a/app/user_store.py
+++ b/app/user_store.py
@@ -1,0 +1,151 @@
+"""Utility module for managing dynamically registered users."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .models import Permission, RuleInfo, UserInfo
+
+logger = logging.getLogger(__name__)
+
+STORE_PATH = Path("data/users.json")
+
+
+def _default_store() -> Dict[str, List[Dict]]:
+    """Return the default empty store structure."""
+    return {"users": []}
+
+
+def _load_store() -> Dict[str, List[Dict]]:
+    """Load the dynamic user store from disk."""
+    try:
+        if not STORE_PATH.exists():
+            return _default_store()
+
+        with STORE_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            logger.warning("Invalid user store structure; resetting store")
+            return _default_store()
+
+        data.setdefault("users", [])
+        if not isinstance(data["users"], list):
+            logger.warning("Invalid users list in store; resetting store")
+            data["users"] = []
+        return data
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to parse user store JSON: %s", exc)
+        return _default_store()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Unexpected error loading user store: %s", exc)
+        return _default_store()
+
+
+def _atomic_write(data: Dict[str, List[Dict]]):
+    """Write store data atomically to disk."""
+    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = STORE_PATH.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    tmp_path.replace(STORE_PATH)
+
+
+def load_registered_entries() -> Tuple[List[UserInfo], List[RuleInfo]]:
+    """Load registered users and their rules from the dynamic store."""
+    store = _load_store()
+    users: List[UserInfo] = []
+    rules: List[RuleInfo] = []
+
+    for entry in store.get("users", []):
+        try:
+            name = entry.get("name")
+            pass_hash = entry.get("pass_hash")
+            is_bcrypt = entry.get("is_bcrypt", True)
+            if not name or not pass_hash:
+                continue
+
+            users.append(UserInfo(name=name, pass_hash=pass_hash, is_bcrypt=is_bcrypt))
+
+            for rule_data in entry.get("rules", []):
+                try:
+                    allow_values = rule_data.get("allow", [Permission.READ.value])
+                    allow = [Permission(value) for value in allow_values]
+                except ValueError:
+                    logger.warning("Invalid permission in rule for user %s", name)
+                    allow = [Permission.READ]
+
+                rule = RuleInfo(
+                    who=name,
+                    allow=allow,
+                    roots=rule_data.get("roots", []),
+                    paths=rule_data.get("paths", ["/"]),
+                    ip_allow=rule_data.get("ip_allow", ["*"]),
+                    ip_deny=rule_data.get("ip_deny", []),
+                )
+                rules.append(rule)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to load user entry: %s", exc)
+            continue
+
+    return users, rules
+
+
+def add_registered_user(
+    username: str,
+    pass_hash: str,
+    roots: List[str],
+    *,
+    permissions: List[Permission] | None = None,
+    paths: List[str] | None = None,
+    ip_allow: List[str] | None = None,
+    ip_deny: List[str] | None = None,
+) -> Tuple[UserInfo, List[RuleInfo]]:
+    """Add a new registered user to the dynamic store.
+
+    Returns the created user info and associated rules.
+    """
+
+    store = _load_store()
+    username_lower = username.lower()
+    for entry in store.get("users", []):
+        if str(entry.get("name", "")).lower() == username_lower:
+            raise ValueError("User already exists")
+
+    permissions = permissions or [Permission.READ, Permission.WRITE, Permission.DELETE]
+    paths = paths or ["/"]
+    ip_allow = ip_allow or ["*"]
+    ip_deny = ip_deny or []
+
+    user_entry = {
+        "name": username,
+        "pass_hash": pass_hash,
+        "is_bcrypt": True,
+        "rules": [
+            {
+                "allow": [perm.value for perm in permissions],
+                "roots": roots,
+                "paths": paths,
+                "ip_allow": ip_allow,
+                "ip_deny": ip_deny,
+            }
+        ],
+    }
+
+    store.setdefault("users", []).append(user_entry)
+    _atomic_write(store)
+
+    user = UserInfo(name=username, pass_hash=pass_hash, is_bcrypt=True)
+    rule = RuleInfo(
+        who=username,
+        allow=list(permissions),
+        roots=roots,
+        paths=paths,
+        ip_allow=ip_allow,
+        ip_deny=ip_deny,
+    )
+
+    return user, [rule]

--- a/chfs.yaml
+++ b/chfs.yaml
@@ -85,7 +85,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py File Server"
   textShareDir: "C:\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB in bytes
+  # maxUploadSize can be set if you want to enforce a limit; omit for unlimited uploads
   language: "en"  # en or zh
 
 # WebDAV configuration

--- a/start-chfs.ps1
+++ b/start-chfs.ps1
@@ -292,7 +292,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py 文件服务器"
   textShareDir: "$currentDir\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB
+  # maxUploadSize: 104857600  # 可选，取消注释以限制上传大小
   language: "zh"
 
 # WebDAV 配置

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,43 +75,91 @@
                     <i class="fas fa-lock text-yellow-600"></i>
                     <div>
                         <h3 class="font-semibold text-yellow-800">Authentication Required</h3>
-                        <p class="text-yellow-700 text-sm mt-1">Please provide credentials to access the file server.</p>
+                        <p class="text-yellow-700 text-sm mt-1">
+                            Please sign in to continue or create an account below.
+                        </p>
                     </div>
                 </div>
             </div>
 
-            <!-- Login form -->
+            <!-- Login / Register forms -->
             <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-                <form class="space-y-5" @submit.prevent="performLogin()">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-username">Username</label>
-                            <input id="login-username" x-ref="loginUsername" type="text" x-model="loginUsername" autocomplete="username"
-                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                   placeholder="Enter username" required>
+                <template x-if="!showRegister">
+                    <form class="space-y-5" @submit.prevent="performLogin()">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="login-username">Username</label>
+                                <input id="login-username" x-ref="loginUsername" type="text" x-model="loginUsername" autocomplete="username"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Enter username" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="login-password">Password</label>
+                                <input id="login-password" type="password" x-model="loginPassword" autocomplete="current-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Enter password" required>
+                            </div>
                         </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1" for="login-password">Password</label>
-                            <input id="login-password" type="password" x-model="loginPassword" autocomplete="current-password"
-                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                   placeholder="Enter password" required>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <label class="inline-flex items-center gap-2 text-sm text-gray-600">
+                                <input type="checkbox" x-model="rememberCredentials" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                Remember credentials on this device
+                            </label>
+                            <div class="flex items-center gap-3">
+                                <button type="submit"
+                                        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">
+                                    <span>Sign In</span>
+                                </button>
+                                <span class="text-xs text-gray-500 hidden sm:block">Default: admin / admin123</span>
+                            </div>
                         </div>
-                    </div>
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                        <label class="inline-flex items-center gap-2 text-sm text-gray-600">
-                            <input type="checkbox" x-model="rememberCredentials" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-                            Remember credentials on this device
-                        </label>
-                        <div class="flex items-center gap-3">
-                            <button type="submit"
-                                    class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">
-                                <span>Sign In</span>
+                        <p x-show="loginInfo" x-text="loginInfo" class="text-sm text-green-600"></p>
+                        <p x-show="loginError" x-text="loginError" class="text-sm text-red-600"></p>
+                        <p class="text-sm text-gray-600">
+                            Don't have an account?
+                            <button type="button" @click="switchToRegister()"
+                                    class="text-blue-600 hover:text-blue-700 font-medium">
+                                Create one now
                             </button>
-                            <span class="text-xs text-gray-500 hidden sm:block">Default: admin / admin123</span>
+                        </p>
+                    </form>
+                </template>
+
+                <template x-if="showRegister">
+                    <form class="space-y-5" @submit.prevent="performRegister()">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-username">Username</label>
+                                <input id="register-username" x-ref="registerUsername" type="text" x-model="registerUsername" autocomplete="username"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Choose a username" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-password">Password</label>
+                                <input id="register-password" type="password" x-model="registerPassword" autocomplete="new-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="At least 6 characters" required>
+                            </div>
+                            <div class="md:col-span-2">
+                                <label class="block text-sm font-medium text-gray-700 mb-1" for="register-confirm">Confirm Password</label>
+                                <input id="register-confirm" type="password" x-model="registerConfirm" autocomplete="new-password"
+                                       class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                       placeholder="Re-enter password" required>
+                            </div>
                         </div>
-                    </div>
-                    <p x-show="loginError" x-text="loginError" class="text-sm text-red-600"></p>
-                </form>
+                        <p x-show="registerError" x-text="registerError" class="text-sm text-red-600"></p>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <button type="button" @click="switchToLogin()"
+                                    class="text-sm text-gray-600 hover:text-gray-800">
+                                Back to sign in
+                            </button>
+                            <button type="submit"
+                                    class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors">
+                                Create Account
+                            </button>
+                        </div>
+                    </form>
+                </template>
             </div>
         </div>
 
@@ -392,6 +440,12 @@
                 loginPassword: '',
                 rememberCredentials: true,
                 loginError: '',
+                loginInfo: '',
+                showRegister: false,
+                registerUsername: '',
+                registerPassword: '',
+                registerConfirm: '',
+                registerError: '',
 
                 // File browser state
                 currentRoot: initialRoots.length > 0 ? initialRoots[0] : '',
@@ -464,6 +518,80 @@
                     });
                 },
 
+                switchToRegister() {
+                    this.showRegister = true;
+                    this.registerUsername = this.loginUsername || '';
+                    this.registerPassword = '';
+                    this.registerConfirm = '';
+                    this.registerError = '';
+                    this.loginError = '';
+                    this.loginInfo = '';
+                    this.$nextTick(() => {
+                        if (this.$refs.registerUsername) {
+                            this.$refs.registerUsername.focus();
+                        }
+                    });
+                },
+
+                switchToLogin(message = '') {
+                    this.showRegister = false;
+                    this.registerUsername = '';
+                    this.registerPassword = '';
+                    this.registerConfirm = '';
+                    this.registerError = '';
+                    if (message) {
+                        this.loginInfo = message;
+                        this.loginError = '';
+                    } else {
+                        this.loginInfo = '';
+                    }
+                    this.$nextTick(() => this.focusLogin());
+                },
+
+                async performRegister() {
+                    const username = (this.registerUsername || '').trim();
+                    this.registerError = '';
+                    this.loginInfo = '';
+                    if (!username || username.length < 3) {
+                        this.registerError = 'Username must be at least 3 characters.';
+                        return;
+                    }
+
+                    if (!this.registerPassword || this.registerPassword.length < 6) {
+                        this.registerError = 'Password must be at least 6 characters.';
+                        return;
+                    }
+
+                    if (this.registerPassword !== this.registerConfirm) {
+                        this.registerError = 'Passwords do not match.';
+                        return;
+                    }
+
+                    try {
+                        const response = await fetch('/api/register', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                username,
+                                password: this.registerPassword,
+                                confirmPassword: this.registerConfirm,
+                            }),
+                        });
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            this.registerError = '';
+                            this.loginUsername = username;
+                            this.loginPassword = '';
+                            this.switchToLogin('Registration successful! Please sign in.');
+                        } else {
+                            this.registerError = payload?.msg || 'Registration failed.';
+                        }
+                    } catch (e) {
+                        this.registerError = 'Registration failed: ' + e.message;
+                    }
+                },
+
                 async tryAutoLogin() {
                     const savedHeader = localStorage.getItem('chfsAuthHeader');
                     const savedUser = localStorage.getItem('chfsAuthUser');
@@ -498,6 +626,7 @@
                     }
                     if (showMessage) {
                         this.loginError = 'Please log in to continue.';
+                        this.loginInfo = '';
                         this.focusLogin();
                     }
                     return false;
@@ -520,18 +649,20 @@
                             headers: this.buildHeaders()
                         });
 
-                        if (response.status === 401) {
-                            if (showErrors) {
-                                this.loginError = 'Invalid username or password.';
-                            }
-                            this.handleUnauthorized(null);
-                            return false;
+                    if (response.status === 401) {
+                        if (showErrors) {
+                            this.loginError = 'Invalid username or password.';
+                            this.loginInfo = '';
                         }
+                        this.handleUnauthorized(null);
+                        return false;
+                    }
 
                         const payload = this.parseApiResponse(await response.json());
                         if (payload.code === 0) {
                             this.isAuthenticated = true;
                             this.loginError = '';
+                            this.loginInfo = '';
                             this.currentUser = payload.data?.user?.name || this.loginUsername;
                             if (!this.loginUsername) {
                                 this.loginUsername = this.currentUser;
@@ -548,11 +679,13 @@
 
                         if (showErrors) {
                             this.loginError = payload.msg || 'Failed to verify credentials.';
+                            this.loginInfo = '';
                         }
                         return false;
                     } catch (e) {
                         if (showErrors) {
                             this.loginError = 'Login failed: ' + e.message;
+                            this.loginInfo = '';
                         }
                         return false;
                     }
@@ -562,8 +695,9 @@
                     const username = (this.loginUsername || '').trim();
                     if (!username || !this.loginPassword) {
                         this.loginError = 'Please enter username and password.';
+                        this.loginInfo = '';
                         this.focusLogin();
-                        return;
+                        return false;
                     }
 
                     try {
@@ -571,13 +705,16 @@
                         this.authHeader = this.createAuthHeader(username, this.loginPassword);
                     } catch (e) {
                         this.loginError = 'Failed to encode credentials.';
-                        return;
+                        this.loginInfo = '';
+                        return false;
                     }
 
                     const success = await this.refreshSession(true);
                     if (success) {
                         this.error = null;
                         this.loginPassword = '';
+                        this.loginError = '';
+                        this.loginInfo = '';
 
                         if (this.rememberCredentials) {
                             localStorage.setItem('chfsAuthHeader', this.authHeader);
@@ -595,6 +732,7 @@
                     } else {
                         this.resetCredentials();
                     }
+                    return success;
                 },
 
                 handleUnauthorized(message = 'Session expired. Please log in again.') {
@@ -618,6 +756,7 @@
                     if (message !== null) {
                         this.error = message;
                         this.loginError = message;
+                        this.loginInfo = '';
                     }
 
                     this.resetCredentials();

--- a/一键部署.ps1
+++ b/一键部署.ps1
@@ -301,7 +301,7 @@ ui:
   brand: "chfs-py"
   title: "文件服务器"
   textShareDir: "$($DataPath.Replace('\', '\\'))\public\_text"
-  maxUploadSize: 104857600
+  # maxUploadSize: 104857600  # 可选，取消注释以限制上传大小
   language: "zh"
 
 dav:

--- a/使用说明.md
+++ b/使用说明.md
@@ -136,7 +136,7 @@ users:
 
 ui:
   language: "zh"      # 界面语言 (zh/en)
-  maxUploadSize: 104857600  # 最大上传大小(字节)
+  # maxUploadSize: 104857600  # 可选，设置后限制最大上传大小
 ```
 
 ### 添加用户


### PR DESCRIPTION
## Summary
- add a FileServer runtime facade so the API delegates storage and registration work to the server layer
- remove the upload size cap by default and accept optional limits when explicitly configured
- update configuration samples and docs to reflect the unlimited upload default

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5e12b64b48327a0ed7571399686b4