### PR TITLE
Refactor storage handling and remove upload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py File Server"
   textShareDir: "C:\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB
+  # maxUploadSize: 104857600  # Optional upload cap (bytes); omit for unlimited uploads
 
 # WebDAV 配置
 dav:

--- a/app/api.py
+++ b/app/api.py
@@ -6,18 +6,15 @@ import logging
 import time
 from pathlib import Path
 from typing import List, Optional
+
 from fastapi import APIRouter, Request, HTTPException, UploadFile, File, Form, Depends
-from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from .models import ApiResponse, ResponseCode, FileInfo, TextShare
 from .auth import get_current_user, UserInfo, hash_password
 from .rules import check_api_access, get_accessible_roots
-from .fs import (
-    list_directory, create_directory, delete_file_or_directory,
-    rename_file_or_directory, save_uploaded_file, open_file_for_download,
-    write_text_file, FileSystemError, PathTraversalError
-)
+from .storage_server import storage_server, FileSystemError
 from .utils import parse_http_range, generate_short_id, create_response_headers
 from .metrics import upload_context, download_context
 from .config import get_config, get_user_by_name
@@ -31,12 +28,6 @@ api_router = APIRouter(prefix="/api", tags=["api"])
 
 # Text shares storage (in-memory for simplicity)
 text_shares = {}
-
-
-class RegisterRequest(BaseModel):
-    username: str
-    password: str
-    confirmPassword: str
 
 
 # Session endpoints
@@ -206,7 +197,7 @@ async def list_files(
         )
     
     try:
-        files = await list_directory(root, path)
+        files = await storage_server.list_files(root, path)
         
         return ApiResponse(
             code=ResponseCode.SUCCESS.value,
@@ -256,8 +247,12 @@ async def upload_file(
     # Check file size
     config = get_config()
     max_size = config.ui.maxUploadSize
-    
-    if file.size and file.size > max_size:
+
+    if (
+        max_size is not None
+        and file.size is not None
+        and file.size > max_size
+    ):
         raise HTTPException(
             status_code=413,
             detail=ApiResponse(
@@ -266,11 +261,15 @@ async def upload_file(
                 data=None
             ).to_dict()
         )
-    
+
     try:
         with upload_context() as counter:
-            bytes_written = await save_uploaded_file(
-                root, path, file.filename or "unnamed", file, max_size
+            bytes_written = await storage_server.upload_file(
+                root,
+                path,
+                file.filename or "unnamed",
+                file,
+                max_size=max_size,
             )
             counter.add_bytes(bytes_written)
         
@@ -318,7 +317,7 @@ async def make_directory(
         )
     
     try:
-        await create_directory(mkdir_req.root, mkdir_req.path)
+        await storage_server.make_directory(mkdir_req.root, mkdir_req.path)
         
         return ApiResponse(
             code=ResponseCode.SUCCESS.value,
@@ -363,7 +362,9 @@ async def rename_item(
         )
     
     try:
-        await rename_file_or_directory(rename_req.root, rename_req.path, rename_req.newName)
+        await storage_server.rename(
+            rename_req.root, rename_req.path, rename_req.newName
+        )
         
         return ApiResponse(
             code=ResponseCode.SUCCESS.value,
@@ -407,7 +408,7 @@ async def delete_items(
             continue
         
         try:
-            await delete_file_or_directory(delete_req.root, path)
+            await storage_server.delete(delete_req.root, path)
             deleted_paths.append(path)
             
         except FileSystemError as e:
@@ -453,7 +454,7 @@ async def download_file(
         http_range = parse_http_range(range_header) if range_header else None
         
         # Open file for download
-        file_generator, start, end, total_size = await open_file_for_download(
+        file_generator, start, end, total_size = await storage_server.open_for_download(
             root, path, http_range
         )
         
@@ -551,7 +552,9 @@ async def create_text_share(
                 ))
                 filename = f"{share_id}.txt"
                 
-                await write_text_file(root_name, f"{rel_path}/{filename}", text_req.text)
+                await storage_server.write_text(
+                    root_name, f"{rel_path}/{filename}", text_req.text
+                )
                 
         except Exception as e:
             logger.warning(f"Failed to save text share to file: {e}")

--- a/app/config.py
+++ b/app/config.py
@@ -159,11 +159,22 @@ class ConfigManager:
         
         # UI
         ui_data = data.get('ui', {})
+        max_upload_size = ui_data.get('maxUploadSize')
+        if max_upload_size is not None:
+            try:
+                max_upload_size = int(max_upload_size)
+            except (TypeError, ValueError):
+                logger.warning("Invalid maxUploadSize value; ignoring limit")
+                max_upload_size = None
+            else:
+                if max_upload_size <= 0:
+                    max_upload_size = None
+
         ui = UiConfig(
             brand=ui_data.get('brand', 'chfs-py'),
             title=ui_data.get('title', 'chfs-py File Server'),
             textShareDir=ui_data.get('textShareDir', ''),
-            maxUploadSize=ui_data.get('maxUploadSize', 104857600),
+            maxUploadSize=max_upload_size,
             language=ui_data.get('language', 'en')
         )
         

--- a/app/models.py
+++ b/app/models.py
@@ -143,7 +143,7 @@ class UiConfig:
     brand: str = "chfs-py"
     title: str = "chfs-py File Server"
     textShareDir: str = ""
-    maxUploadSize: int = 104857600  # 100MB
+    maxUploadSize: Optional[int] = None
     language: str = "en"
 
 

--- a/app/storage_server.py
+++ b/app/storage_server.py
@@ -1,0 +1,95 @@
+"""Server-side storage orchestration layer."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, List, Optional, Tuple
+import logging
+
+from fastapi import UploadFile
+
+from .fs import (
+    list_directory,
+    create_directory,
+    delete_file_or_directory,
+    rename_file_or_directory,
+    save_uploaded_file,
+    open_file_for_download,
+    write_text_file,
+    FileSystemError,
+)
+from .models import FileInfo, HttpRange
+
+logger = logging.getLogger(__name__)
+
+
+class StorageServer:
+    """Encapsulates all server-side storage operations."""
+
+    async def list_files(self, root_name: str, rel_path: str) -> List[FileInfo]:
+        logger.debug("Listing files", extra={"root": root_name, "path": rel_path})
+        return await list_directory(root_name, rel_path)
+
+    async def upload_file(
+        self,
+        root_name: str,
+        rel_path: str,
+        filename: str,
+        upload_file_obj: UploadFile,
+        *,
+        max_size: Optional[int] = None,
+    ) -> int:
+        logger.debug(
+            "Uploading file",
+            extra={"root": root_name, "path": rel_path, "filename": filename},
+        )
+        return await save_uploaded_file(
+            root_name,
+            rel_path,
+            filename,
+            upload_file_obj,
+            max_size=max_size,
+        )
+
+    async def make_directory(self, root_name: str, rel_path: str) -> None:
+        logger.debug("Creating directory", extra={"root": root_name, "path": rel_path})
+        await create_directory(root_name, rel_path)
+
+    async def rename(self, root_name: str, rel_path: str, new_name: str) -> None:
+        logger.debug(
+            "Renaming entry",
+            extra={"root": root_name, "path": rel_path, "new_name": new_name},
+        )
+        await rename_file_or_directory(root_name, rel_path, new_name)
+
+    async def delete(self, root_name: str, rel_path: str) -> None:
+        logger.debug("Deleting entry", extra={"root": root_name, "path": rel_path})
+        await delete_file_or_directory(root_name, rel_path)
+
+    async def open_for_download(
+        self,
+        root_name: str,
+        rel_path: str,
+        http_range: Optional[HttpRange] = None,
+    ) -> Tuple[AsyncGenerator[bytes, None], int, int, int]:
+        logger.debug(
+            "Opening file for download",
+            extra={"root": root_name, "path": rel_path},
+        )
+        return await open_file_for_download(root_name, rel_path, http_range)
+
+    async def write_text(
+        self,
+        root_name: str,
+        rel_path: str,
+        content: str,
+    ) -> int:
+        logger.debug(
+            "Writing text file",
+            extra={"root": root_name, "path": rel_path},
+        )
+        return await write_text_file(root_name, rel_path, content)
+
+
+storage_server = StorageServer()
+
+__all__ = ["storage_server", "StorageServer", "FileSystemError"]

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for chfs-py
-"""
+"""Utility functions for chfs-py."""
 
 import hashlib
 import mimetypes

--- a/chfs.yaml
+++ b/chfs.yaml
@@ -85,7 +85,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py File Server"
   textShareDir: "C:\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB in bytes
+  # maxUploadSize: 104857600  # Optional upload cap (bytes); remove or set <=0 for unlimited
   language: "en"  # en or zh
 
 # WebDAV configuration

--- a/start-chfs.ps1
+++ b/start-chfs.ps1
@@ -292,7 +292,7 @@ ui:
   brand: "chfs-py"
   title: "chfs-py 文件服务器"
   textShareDir: "$currentDir\\chfs-data\\public\\_text"
-  maxUploadSize: 104857600  # 100MB
+  # maxUploadSize: 104857600  # Optional upload cap (bytes); omit for unlimited
   language: "zh"
 
 # WebDAV 配置

--- a/一键部署.ps1
+++ b/一键部署.ps1
@@ -301,7 +301,7 @@ ui:
   brand: "chfs-py"
   title: "文件服务器"
   textShareDir: "$($DataPath.Replace('\', '\\'))\public\_text"
-  maxUploadSize: 104857600
+  # maxUploadSize: 104857600  # Optional upload cap (bytes); omit for unlimited
   language: "zh"
 
 dav:

--- a/使用说明.md
+++ b/使用说明.md
@@ -136,7 +136,7 @@ users:
 
 ui:
   language: "zh"      # 界面语言 (zh/en)
-  maxUploadSize: 104857600  # 最大上传大小(字节)
+  # maxUploadSize: 104857600  # 可选上传上限(字节)，留空或小于等于0表示不限
 ```
 
 ### 添加用户


### PR DESCRIPTION
## Summary
- remove the global upload size ceiling by making the limit optional in configuration and filesystem code, and refresh the documentation examples
- introduce a storage service layer so all file operations are driven by the server side while the client UI keeps its existing behavior
- fix missing module imports and docstrings uncovered while refactoring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5e90130a8832799f7f9d157f7e3c7