### PR TITLE
Add LAN control panel and status endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -22,6 +22,7 @@ from .metrics import upload_context, download_context
 from .config import get_config, get_user_by_name
 from .ipfilter import get_client_ip
 from .user_store import add_registered_user
+from .control_panel import build_control_panel_state
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,18 @@ async def get_session(request: Request, user: UserInfo = Depends(get_current_use
             "user": {"name": user.name},
             "roots": roots,
         }
+    ).to_dict()
+
+
+@api_router.get("/admin/status")
+async def get_admin_status(user: UserInfo = Depends(get_current_user)):
+    """Return consolidated information for the server control panel."""
+
+    status = build_control_panel_state(user.name)
+    return ApiResponse(
+        code=ResponseCode.SUCCESS.value,
+        msg="success",
+        data=status,
     ).to_dict()
 
 

--- a/app/control_panel.py
+++ b/app/control_panel.py
@@ -1,0 +1,191 @@
+"""Utilities for assembling the server-side control panel payload."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import platform
+import shutil
+import socket
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+
+from .config import get_config
+from .ipfilter import parse_cidr
+from .metrics import metrics_manager
+
+logger = logging.getLogger(__name__)
+
+# Common private network ranges that should stay reachable inside a LAN
+Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+_PRIVATE_NETWORKS: Tuple[Network, ...] = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local
+    ipaddress.ip_network("fc00::/7"),  # unique local IPv6 addresses
+)
+
+
+def _format_host(address: str) -> str:
+    """Return host formatted for URLs, wrapping IPv6 in brackets."""
+
+    if ":" in address and not address.startswith("["):
+        return f"[{address}]"
+    return address
+
+
+def _safe_disk_usage(path: Path) -> Optional[Dict[str, int]]:
+    """Return disk usage statistics for the given path if available."""
+
+    try:
+        target = path if path.exists() else path.parent
+        if not target.exists():
+            return None
+        usage = shutil.disk_usage(target)
+        return {
+            "total": usage.total,
+            "used": usage.total - usage.free,
+            "free": usage.free,
+        }
+    except OSError as exc:
+        logger.debug("Failed to read disk usage for \%s: %s", path, exc)
+        return None
+
+
+def _share_status(share) -> Dict[str, Any]:
+    """Build share status payload."""
+
+    path = Path(share.path)
+    exists = path.exists()
+    status = {
+        "name": share.name,
+        "path": str(path),
+        "exists": exists,
+        "readable": os.access(path, os.R_OK) if exists else False,
+        "writable": os.access(path, os.W_OK) if exists else False,
+    }
+
+    disk = _safe_disk_usage(path)
+    if disk:
+        status["disk"] = disk
+    return status
+
+
+def _discover_local_addresses() -> List[str]:
+    """Try to discover non-loopback addresses for quick LAN access."""
+
+    addresses: Set[str] = set()
+
+    # Resolve hostname interfaces
+    hostname = socket.gethostname()
+    for family in (socket.AF_INET, socket.AF_INET6):
+        try:
+            infos = socket.getaddrinfo(hostname, None, family, socket.SOCK_STREAM)
+        except socket.gaierror:
+            continue
+
+        for info in infos:
+            addr = info[4][0]
+            if not addr:
+                continue
+
+            if family == socket.AF_INET:
+                if addr.startswith("127."):
+                    continue
+                addresses.add(addr)
+            else:
+                if addr.startswith("::1"):
+                    continue
+                addr = addr.split("%", 1)[0]  # strip scope
+                addresses.add(addr)
+
+    # UDP connect trick to learn outbound interface
+    for target in (("8.8.8.8", 80), ("1.1.1.1", 80)):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(target)
+                addr = sock.getsockname()[0]
+                if not addr.startswith("127."):
+                    addresses.add(addr)
+        except OSError:
+            continue
+
+    if not addresses:
+        addresses.add("127.0.0.1")
+
+    return sorted(addresses)
+
+
+def _overlaps_private(network: Network) -> bool:
+    for private in _PRIVATE_NETWORKS:
+        if network.version != private.version:
+            continue
+        if network.overlaps(private):
+            return True
+    return False
+
+
+def _summarize_ip_filter(allow_list: Iterable[str], deny_list: Iterable[str]) -> Dict[str, Any]:
+    allow_networks = [parse_cidr(entry) for entry in allow_list or []]
+    allow_networks = [net for net in allow_networks if net is not None]
+
+    deny_networks = [parse_cidr(entry) for entry in deny_list or []]
+    deny_networks = [net for net in deny_networks if net is not None]
+
+    has_allow_rules = bool(allow_networks)
+    lan_allowing = [str(net) for net in allow_networks if _overlaps_private(net)]
+    lan_blocking = [str(net) for net in deny_networks if _overlaps_private(net)]
+
+    lan_access = (not has_allow_rules or bool(lan_allowing)) and not lan_blocking
+
+    return {
+        "allow": list(allow_list or []),
+        "deny": list(deny_list or []),
+        "allow_count": len(allow_networks),
+        "deny_count": len(deny_networks),
+        "mode": "allowlist" if has_allow_rules else "deny-only",
+        "lan_allowed": lan_access,
+        "lan_allowing_rules": lan_allowing,
+        "lan_blocking_rules": lan_blocking,
+    }
+
+
+def build_control_panel_state(current_user: str) -> Dict[str, Any]:
+    """Return the payload consumed by the front-end control panel."""
+
+    config = get_config()
+    metrics = metrics_manager.get_metrics()
+
+    scheme = "https" if config.server.tls.enabled else "http"
+    lan_addresses = _discover_local_addresses()
+
+    lan_urls: List[str] = [
+        f"{scheme}://{_format_host(address)}:{config.server.port}" for address in lan_addresses
+    ]
+
+    bind_all = config.server.addr in {"0.0.0.0", "::"}
+    if not bind_all:
+        lan_urls.insert(0, f"{scheme}://{_format_host(config.server.addr)}:{config.server.port}")
+
+    shares = [_share_status(share) for share in config.shares]
+
+    return {
+        "user": {"name": current_user},
+        "server": {
+            "host": config.server.addr,
+            "port": config.server.port,
+            "scheme": scheme,
+            "bind_all_interfaces": bind_all,
+            "lan_urls": lan_urls,
+        },
+        "shares": shares,
+        "metrics": metrics,
+        "ip_filter": _summarize_ip_filter(config.ipFilter.allow, config.ipFilter.deny),
+        "environment": {
+            "platform": platform.platform(),
+            "python_version": platform.python_version(),
+            "working_directory": str(Path.cwd()),
+        },
+    }

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,6 +50,11 @@
                                 <i class="fas fa-share-alt"></i>
                                 <span class="hidden sm:inline">Share Text</span>
                             </button>
+                            <button @click="openControlPanel()"
+                                    class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                                <i class="fas fa-sliders-h"></i>
+                                <span class="hidden sm:inline">Control Panel</span>
+                            </button>
                             <button @click="logout()"
                                     class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded-lg transition-colors">
                                 <i class="fas fa-sign-out-alt"></i>
@@ -407,18 +412,266 @@
         <div x-show="showRename" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
             <div class="bg-white rounded-lg max-w-md w-full p-6" @click.away="showRename = false">
                 <h3 class="text-lg font-semibold mb-4">Rename</h3>
-                <input type="text" x-model="renameValue" placeholder="New name" 
+                <input type="text" x-model="renameValue" placeholder="New name"
                        class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                        @keyup.enter="confirmRename()">
                 <div class="flex justify-end gap-3 mt-6">
                     <button @click="showRename = false" class="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors">
                         Cancel
                     </button>
-                    <button @click="confirmRename()" 
+                    <button @click="confirmRename()"
                             :disabled="!renameValue.trim()"
                             class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors">
                         Rename
                     </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Control Panel Modal -->
+        <div x-show="showControlPanel" @keydown.escape.window="closeControlPanel()"
+             class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
+            <div class="bg-white rounded-lg shadow-2xl max-w-5xl w-full p-6 overflow-hidden" @click.away="closeControlPanel()">
+                <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4">
+                    <div>
+                        <h3 class="text-xl font-semibold text-gray-900">Server Control Panel</h3>
+                        <p class="text-sm text-gray-500 mt-1">
+                            <span x-show="controlPanelTimestamp" x-text="'Last updated: ' + controlPanelTimestamp"></span>
+                            <span x-show="!controlPanelTimestamp">Load the latest status to view live metrics.</span>
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <button @click="refreshControlPanel()"
+                                class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                            <i class="fas fa-rotate"></i>
+                            <span>Refresh</span>
+                        </button>
+                        <button @click="closeControlPanel()"
+                                class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded-lg transition-colors">
+                            Close
+                        </button>
+                    </div>
+                </div>
+
+                <div x-show="controlPanelLoading"
+                     class="flex items-center gap-2 bg-blue-50 border border-blue-100 text-blue-700 px-4 py-3 rounded-lg mb-4">
+                    <i class="fas fa-circle-notch fa-spin"></i>
+                    <span>Loading latest server information…</span>
+                </div>
+
+                <div x-show="controlPanelError"
+                     class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4"
+                     x-text="controlPanelError"></div>
+
+                <div x-show="!controlPanelLoading && controlPanelData" class="space-y-6 max-h-[70vh] overflow-y-auto pr-1">
+                    <section class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-3">
+                            <div>
+                                <h4 class="text-lg font-semibold text-gray-800">Quick LAN Access</h4>
+                                <p class="text-sm text-gray-600">Share these URLs with other devices on your network.</p>
+                            </div>
+                            <span class="text-xs font-semibold px-3 py-1 rounded-full"
+                                  :class="(controlPanelData?.ip_filter?.lan_allowed ?? false) ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'">
+                                <span x-text="(controlPanelData?.ip_filter?.lan_allowed ?? false) ? 'LAN Reachable' : 'LAN Restricted'"></span>
+                            </span>
+                        </div>
+                        <ul class="space-y-2">
+                            <template x-for="url in (controlPanelData?.server?.lan_urls || [])" :key="url">
+                                <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 bg-white border border-gray-200 rounded-lg px-3 py-2">
+                                    <span class="text-sm font-mono text-gray-800 truncate" x-text="url"></span>
+                                    <a :href="url" target="_blank" rel="noopener"
+                                       class="text-blue-600 hover:text-blue-700 text-sm font-medium flex items-center gap-1">
+                                        <i class="fas fa-arrow-up-right-from-square"></i>
+                                        Open
+                                    </a>
+                                </li>
+                            </template>
+                            <li x-show="(controlPanelData?.server?.lan_urls || []).length === 0"
+                                class="text-sm text-gray-500">
+                                No LAN addresses detected. The server currently binds to
+                                <span class="font-mono" x-text="controlPanelData?.server?.host"></span>.
+                            </li>
+                        </ul>
+                    </section>
+
+                    <section class="grid md:grid-cols-2 gap-4">
+                        <div class="bg-white border border-gray-200 rounded-lg p-4">
+                            <h4 class="font-semibold text-gray-800 mb-2">IP Filter Configuration</h4>
+                            <p class="text-sm text-gray-600 mb-3">
+                                Mode:
+                                <span class="font-medium text-gray-800" x-text="controlPanelData?.ip_filter?.mode || 'unknown'"></span>
+                            </p>
+                            <div class="space-y-2 text-sm text-gray-700">
+                                <div class="font-medium text-gray-700">Allow rules (<span x-text="controlPanelData?.ip_filter?.allow_count ?? 0"></span>)</div>
+                                <ul class="list-disc list-inside" x-show="(controlPanelData?.ip_filter?.allow || []).length">
+                                    <template x-for="rule in controlPanelData?.ip_filter?.allow" :key="`allow-${rule}`">
+                                        <li x-text="rule"></li>
+                                    </template>
+                                </ul>
+                                <p x-show="!(controlPanelData?.ip_filter?.allow || []).length" class="text-gray-500">
+                                    No explicit allow rules; all addresses are permitted unless denied.
+                                </p>
+                            </div>
+                            <div class="mt-4 space-y-2 text-sm text-gray-700">
+                                <div class="font-medium text-gray-700">Deny rules (<span x-text="controlPanelData?.ip_filter?.deny_count ?? 0"></span>)</div>
+                                <ul class="list-disc list-inside" x-show="(controlPanelData?.ip_filter?.deny || []).length">
+                                    <template x-for="rule in controlPanelData?.ip_filter?.deny" :key="`deny-${rule}`">
+                                        <li x-text="rule"></li>
+                                    </template>
+                                </ul>
+                                <p x-show="!(controlPanelData?.ip_filter?.deny || []).length" class="text-gray-500">
+                                    No deny rules are configured.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="bg-white border border-gray-200 rounded-lg p-4 space-y-2">
+                            <h4 class="font-semibold text-gray-800">LAN Reachability Details</h4>
+                            <p class="text-sm text-gray-600" x-show="controlPanelData?.ip_filter?.lan_allowed">
+                                Private network traffic is currently allowed. These rules grant access:
+                            </p>
+                            <ul class="list-disc list-inside text-sm text-gray-700"
+                                x-show="(controlPanelData?.ip_filter?.lan_allowing_rules || []).length">
+                                <template x-for="rule in controlPanelData?.ip_filter?.lan_allowing_rules" :key="`lan-allow-${rule}`">
+                                    <li x-text="rule"></li>
+                                </template>
+                            </ul>
+                            <p class="text-sm text-red-600" x-show="!(controlPanelData?.ip_filter?.lan_allowed)">
+                                Private networks are blocked by the current rules. Add your LAN ranges to the allow list or remove blocking entries.
+                            </p>
+                            <ul class="list-disc list-inside text-sm text-red-600"
+                                x-show="(controlPanelData?.ip_filter?.lan_blocking_rules || []).length">
+                                <template x-for="rule in controlPanelData?.ip_filter?.lan_blocking_rules" :key="`lan-block-${rule}`">
+                                    <li x-text="rule"></li>
+                                </template>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <section class="bg-white border border-gray-200 rounded-lg p-4">
+                        <div class="flex items-center justify-between mb-3">
+                            <h4 class="text-lg font-semibold text-gray-800">Shares</h4>
+                            <span class="text-xs text-gray-500" x-text="`Configured: ${(controlPanelData?.shares || []).length}`"></span>
+                        </div>
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                                <thead class="bg-gray-100">
+                                    <tr>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-600">Name</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-600">Path</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-600">Status</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-600">Disk</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100">
+                                    <template x-for="share in (controlPanelData?.shares || [])" :key="share.name">
+                                        <tr>
+                                            <td class="px-3 py-2 font-medium text-gray-800" x-text="share.name"></td>
+                                            <td class="px-3 py-2 font-mono text-xs text-gray-600 truncate" x-text="share.path"></td>
+                                            <td class="px-3 py-2">
+                                                <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-semibold"
+                                                      :class="share.exists ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'">
+                                                    <i :class="share.exists ? 'fas fa-check' : 'fas fa-triangle-exclamation'"></i>
+                                                    <span x-text="share.exists ? 'Available' : 'Missing'"></span>
+                                                </span>
+                                                <div class="text-xs text-gray-500 mt-1 flex items-center gap-2">
+                                                    <span :class="share.readable ? 'text-green-600' : 'text-red-600'">
+                                                        <i class="fas fa-eye"></i>
+                                                        <span x-text="share.readable ? 'readable' : 'no read access'"></span>
+                                                    </span>
+                                                    <span class="text-gray-400">•</span>
+                                                    <span :class="share.writable ? 'text-green-600' : 'text-red-600'">
+                                                        <i class="fas fa-pen"></i>
+                                                        <span x-text="share.writable ? 'writable' : 'read-only'"></span>
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td class="px-3 py-2 text-xs text-gray-600">
+                                                <template x-if="share.disk">
+                                                    <div class="space-y-1">
+                                                        <div>
+                                                            <span class="font-medium text-gray-700">Total:</span>
+                                                            <span x-text="formatFileSize(share.disk.total)"></span>
+                                                        </div>
+                                                        <div>
+                                                            <span class="font-medium text-gray-700">Free:</span>
+                                                            <span x-text="formatFileSize(share.disk.free)"></span>
+                                                        </div>
+                                                    </div>
+                                                </template>
+                                                <p x-show="!share.disk" class="text-gray-400">Disk usage unavailable</p>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                    <tr x-show="(controlPanelData?.shares || []).length === 0">
+                                        <td colspan="4" class="px-3 py-4 text-center text-gray-500">No shares configured.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+
+                    <section class="grid md:grid-cols-2 gap-4">
+                        <div class="bg-white border border-gray-200 rounded-lg p-4">
+                            <h4 class="text-lg font-semibold text-gray-800 mb-3">Traffic &amp; Performance</h4>
+                            <div class="grid grid-cols-2 gap-3 text-sm">
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Total Requests</div>
+                                    <div class="text-xl font-semibold text-gray-900" x-text="controlPanelData?.metrics?.requests?.total ?? 0"></div>
+                                </div>
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Active Requests</div>
+                                    <div class="text-xl font-semibold text-gray-900" x-text="controlPanelData?.metrics?.requests?.active ?? 0"></div>
+                                </div>
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Avg Response (s)</div>
+                                    <div class="text-xl font-semibold text-gray-900" x-text="(controlPanelData?.metrics?.requests?.avg_response_time ?? 0).toFixed(3)"></div>
+                                </div>
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Uptime (s)</div>
+                                    <div class="text-xl font-semibold text-gray-900" x-text="Math.round(controlPanelData?.metrics?.uptime_seconds ?? 0)"></div>
+                                </div>
+                            </div>
+                            <div class="mt-4 grid grid-cols-2 gap-3 text-sm">
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Uploaded</div>
+                                    <div class="text-base font-semibold text-gray-900" x-text="formatFileSize(controlPanelData?.metrics?.transfer?.upload_bytes || 0)"></div>
+                                </div>
+                                <div class="bg-gray-50 rounded-lg p-3">
+                                    <div class="text-gray-500">Downloaded</div>
+                                    <div class="text-base font-semibold text-gray-900" x-text="formatFileSize(controlPanelData?.metrics?.transfer?.download_bytes || 0)"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-white border border-gray-200 rounded-lg p-4">
+                            <h4 class="text-lg font-semibold text-gray-800 mb-3">Environment</h4>
+                            <dl class="space-y-2 text-sm text-gray-700">
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Bind Address</dt>
+                                    <dd class="font-mono text-xs" x-text="controlPanelData?.server?.host"></dd>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Port</dt>
+                                    <dd class="font-mono text-xs" x-text="controlPanelData?.server?.port"></dd>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Scheme</dt>
+                                    <dd class="font-mono text-xs" x-text="controlPanelData?.server?.scheme"></dd>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Platform</dt>
+                                    <dd class="font-mono text-xs" x-text="controlPanelData?.environment?.platform"></dd>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Python</dt>
+                                    <dd class="font-mono text-xs" x-text="controlPanelData?.environment?.python_version"></dd>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <dt class="font-medium text-gray-600 w-32">Working Dir</dt>
+                                    <dd class="font-mono text-xs truncate" x-text="controlPanelData?.environment?.working_directory"></dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -460,6 +713,11 @@
                 showNewFolder: false,
                 showTextShare: false,
                 showRename: false,
+                showControlPanel: false,
+                controlPanelLoading: false,
+                controlPanelError: '',
+                controlPanelData: null,
+                controlPanelFetchedAt: null,
 
                 // Form data
                 uploadFiles: [],
@@ -486,6 +744,10 @@
                 // Computed
                 get pathParts() {
                     return this.currentPath ? this.currentPath.split('/').filter(p => p) : [];
+                },
+
+                get controlPanelTimestamp() {
+                    return this.controlPanelFetchedAt ? new Date(this.controlPanelFetchedAt).toLocaleString() : '';
                 },
 
                 buildHeaders(additional = {}) {
@@ -632,6 +894,60 @@
                     return false;
                 },
 
+                async loadControlPanel(force = false) {
+                    if (!this.ensureAuthenticated(false)) {
+                        return;
+                    }
+                    if (this.controlPanelLoading) {
+                        return;
+                    }
+                    if (!force && this.controlPanelData) {
+                        return;
+                    }
+
+                    this.controlPanelLoading = true;
+                    this.controlPanelError = '';
+
+                    try {
+                        const response = await fetch('/api/admin/status', {
+                            headers: this.buildHeaders()
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (payload.code === 0) {
+                            this.controlPanelData = payload.data || {};
+                            this.controlPanelFetchedAt = new Date().toISOString();
+                        } else {
+                            this.controlPanelError = payload.msg || 'Failed to load control panel data.';
+                        }
+                    } catch (e) {
+                        this.controlPanelError = 'Failed to load control panel data: ' + e.message;
+                    } finally {
+                        this.controlPanelLoading = false;
+                    }
+                },
+
+                async openControlPanel() {
+                    if (!this.ensureAuthenticated()) {
+                        return;
+                    }
+                    this.showControlPanel = true;
+                    await this.loadControlPanel(true);
+                },
+
+                async refreshControlPanel() {
+                    await this.loadControlPanel(true);
+                },
+
+                closeControlPanel() {
+                    this.showControlPanel = false;
+                },
+
                 parseApiResponse(data) {
                     if (data && typeof data === 'object' && 'detail' in data) {
                         return data.detail;
@@ -746,12 +1062,17 @@
                     this.showNewFolder = false;
                     this.showTextShare = false;
                     this.showRename = false;
+                    this.showControlPanel = false;
                     this.uploadFiles = [];
                     this.uploading = false;
                     this.shareText = '';
                     this.shareUrl = '';
                     this.renameTarget = null;
                     this.renameValue = '';
+                    this.controlPanelData = null;
+                    this.controlPanelError = '';
+                    this.controlPanelFetchedAt = null;
+                    this.controlPanelLoading = false;
 
                     if (message !== null) {
                         this.error = message;
@@ -777,12 +1098,17 @@
                     this.showNewFolder = false;
                     this.showTextShare = false;
                     this.showRename = false;
+                    this.showControlPanel = false;
                     this.uploadFiles = [];
                     this.uploading = false;
                     this.shareText = '';
                     this.shareUrl = '';
                     this.renameTarget = null;
                     this.renameValue = '';
+                    this.controlPanelData = null;
+                    this.controlPanelError = '';
+                    this.controlPanelFetchedAt = null;
+                    this.controlPanelLoading = false;
                     this.resetCredentials();
                     this.focusLogin();
                 },

--- a/tests/test_control_panel.py
+++ b/tests/test_control_panel.py
@@ -1,0 +1,108 @@
+"""Tests for the administrative control panel API."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+pytest.importorskip("httpx", reason="httpx is required for TestClient")
+
+from fastapi.testclient import TestClient
+
+from app.auth import create_basic_auth_header
+from app.main import create_app
+
+
+@pytest.fixture()
+def admin_client(tmp_path):
+    """Create a FastAPI test client with a temporary configuration."""
+
+    share_dir = tmp_path / "shares" / "public"
+    share_dir.mkdir(parents=True)
+
+    config = textwrap.dedent(
+        f"""
+        server:
+          addr: "0.0.0.0"
+          port: 18080
+          tls:
+            enabled: false
+            certfile: ""
+            keyfile: ""
+        shares:
+          - name: "public"
+            path: "{share_dir.as_posix()}"
+        users:
+          - name: "admin"
+            pass: "admin123"
+            pass_bcrypt: false
+        rules:
+          - who: "admin"
+            allow: ["R", "W", "D"]
+            roots: ["public"]
+            paths: ["/"]
+            ip_allow: ["*"]
+            ip_deny: []
+        logging:
+          json: false
+          file: ""
+          level: "INFO"
+          max_size_mb: 10
+          backup_count: 1
+        rateLimit:
+          rps: 50
+          burst: 100
+          maxConcurrent: 10
+        ipFilter:
+          allow:
+            - "*"
+          deny: []
+        ui:
+          brand: "Test"
+          title: "Test Panel"
+          textShareDir: "{(tmp_path / 'text').as_posix()}"
+          language: "en"
+        dav:
+          enabled: false
+          mountPath: "/webdav"
+          lockManager: false
+          propertyManager: false
+        hotReload:
+          enabled: false
+          watchConfig: false
+          debounceMs: 1000
+        """
+    )
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config, encoding="utf-8")
+
+    app = create_app(str(config_path))
+    with TestClient(app) as client:
+        yield client
+
+
+def test_admin_status_requires_auth(admin_client):
+    """The control panel endpoint should reject anonymous access."""
+
+    response = admin_client.get("/api/admin/status")
+    assert response.status_code == 401
+
+
+def test_admin_status_returns_server_snapshot(admin_client):
+    """Authenticated requests receive a comprehensive status payload."""
+
+    headers = {"Authorization": create_basic_auth_header("admin", "admin123")}
+    response = admin_client.get("/api/admin/status", headers=headers)
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["code"] == 0
+
+    data = payload["data"]
+    assert data["server"]["port"] == 18080
+    assert data["server"]["scheme"] == "http"
+    assert data["ip_filter"]["lan_allowed"] is True
+    assert any(url.startswith("http://") for url in data["server"]["lan_urls"])
+    assert data["shares"][0]["name"] == "public"

--- a/tests/test_ipfilter.py
+++ b/tests/test_ipfilter.py
@@ -128,7 +128,25 @@ class TestIpFiltering:
         # Should allow IPs not in deny list
         assert check_ip_allowed("172.16.0.1", allow_list, deny_list)
         assert check_ip_allowed("8.8.8.8", allow_list, deny_list)
-    
+
+    def test_allow_list_overrides_generic_deny(self):
+        """Allow list should override a generic deny-all rule."""
+
+        allow_list = ["192.168.1.0/24"]
+        deny_list = ["0.0.0.0/0"]
+
+        assert check_ip_allowed("192.168.1.10", allow_list, deny_list)
+        assert not check_ip_allowed("8.8.8.8", allow_list, deny_list)
+
+    def test_more_specific_deny_overrides_allow(self):
+        """More specific deny rules should still block access."""
+
+        allow_list = ["192.168.0.0/16"]
+        deny_list = ["192.168.1.100/32"]
+
+        assert not check_ip_allowed("192.168.1.100", allow_list, deny_list)
+        assert check_ip_allowed("192.168.1.101", allow_list, deny_list)
+
     def test_allow_and_deny_lists(self):
         """Test combination of allow and deny lists"""
         


### PR DESCRIPTION
## Summary
- add a backend control panel status endpoint and helper that aggregates LAN access details, metrics, share health, and IP filter summaries
- extend the web UI with an authenticated control panel overlay that surfaces quick-access LAN URLs, server health insights, and an entry point button
- cover the new endpoint with integration tests using a temporary configuration and skip gracefully when httpx is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5f5f013a48327806627af691e8304