### PR TITLE
Add Windows control console and share quota management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 📱 **响应式 UI**: 原生 HTML + Tailwind CDN，移动端友好
 - 🔗 **文本快速分享**: 生成短链 `/t/<id>` 用于文本分享
 - 🚀 **Windows 兼容**: 正确处理反斜杠与 UTF-8 文件名，防目录穿越
+- 📦 **共享目录配额**: 可为每个共享目录设定存储上限，防止空间被占满
 - 📥 **范围下载**: HTTP Range 支持，适合大文件和断点续传
 
 ### 中间件与可观测性
@@ -82,6 +83,14 @@ docker run -d \
 .\scripts\install-service.ps1 -Action uninstall
 ```
 
+#### 4. 本地服务器控制台
+
+```powershell
+pwsh .\scripts\server-control.ps1 -ServerUrl "http://127.0.0.1:8080"
+```
+
+该控制台提供共享目录配额管理、服务器状态查看以及动态用户移除功能。出于安全考虑，相关 API 仅允许在服务器本机访问。
+
 ### 访问服务
 
 - **Web 界面**: http://127.0.0.1:8080
@@ -143,6 +152,7 @@ server:
 shares:
   - name: "public"
     path: "C:\\chfs-data\\public"
+    quota: "50GB"  # 可选：10GB、500MB 等格式，留空表示无限制
   - name: "home"
     path: "C:\\chfs-data\\home"
 
@@ -202,6 +212,8 @@ dav:
   enabled: true
   mountPath: "/webdav"
 ```
+
+> 提示：运行时通过控制台或 REST API 修改的配额会写入 `data/shares.json`，无需手动编辑 `chfs.yaml`。
 
 ## 🔐 Security / 安全性
 

--- a/app/models.py
+++ b/app/models.py
@@ -77,12 +77,18 @@ class UserInfo:
 @dataclass
 class ShareInfo:
     """Share configuration"""
+
     name: str
     path: Path
-    
+    quota_bytes: Optional[int] = None
+
     def __post_init__(self):
         if isinstance(self.path, str):
             self.path = Path(self.path).resolve()
+
+        if self.quota_bytes is not None and self.quota_bytes <= 0:
+            # Normalise non-positive values to unlimited
+            self.quota_bytes = None
 
 
 @dataclass

--- a/app/quota.py
+++ b/app/quota.py
@@ -1,0 +1,125 @@
+"""Share quota management utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .models import ShareInfo
+from .utils import format_file_size
+
+
+@dataclass
+class ShareQuotaExceededError(Exception):
+    """Raised when a share exceeds its configured quota."""
+
+    share: str
+    quota_bytes: int
+    usage_bytes: int
+
+    def __post_init__(self):
+        limit = format_file_size(self.quota_bytes)
+        used = format_file_size(self.usage_bytes)
+        super().__init__(
+            f"Share '{self.share}' quota exceeded: {used} used / {limit} limit"
+        )
+
+
+class ShareQuotaManager:
+    """Helper that keeps track of share usage for quota enforcement."""
+
+    def __init__(self):
+        self._cache: Dict[str, tuple[float, int]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+        self._locks_guard = asyncio.Lock()
+
+    async def _get_lock(self, share_name: str) -> asyncio.Lock:
+        async with self._locks_guard:
+            lock = self._locks.get(share_name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[share_name] = lock
+            return lock
+
+    async def _calculate_usage(self, share: ShareInfo) -> int:
+        path = Path(share.path)
+
+        def _walk(target: Path) -> int:
+            if not target.exists():
+                return 0
+
+            total = 0
+            for root, _, files in os.walk(target):
+                for filename in files:
+                    file_path = Path(root) / filename
+                    try:
+                        total += file_path.stat().st_size
+                    except OSError:
+                        continue
+            return total
+
+        return await asyncio.to_thread(_walk, path)
+
+    async def get_usage(self, share: ShareInfo, *, force: bool = False) -> int:
+        """Return current share usage in bytes."""
+
+        lock = await self._get_lock(share.name)
+        async with lock:
+            if not force and share.name in self._cache:
+                return self._cache[share.name][1]
+
+            usage = await self._calculate_usage(share)
+            self._cache[share.name] = (time.time(), usage)
+            return usage
+
+    async def refresh_usage(self, share: ShareInfo) -> int:
+        """Force-refresh usage for a share and return the new value."""
+
+        return await self.get_usage(share, force=True)
+
+    def invalidate(self, share_name: str) -> None:
+        """Invalidate cached usage for a share."""
+
+        self._cache.pop(share_name, None)
+
+    def ensure_within_quota(self, share: ShareInfo, usage: int) -> None:
+        """Raise if usage exceeds the configured quota."""
+
+        if share.quota_bytes is None:
+            return
+
+        if usage > share.quota_bytes:
+            raise ShareQuotaExceededError(share=share.name, quota_bytes=share.quota_bytes, usage_bytes=usage)
+
+    def describe_quota(self, share: ShareInfo, usage: int) -> Optional[Dict[str, Any]]:
+        """Return helper values describing quota state for UI payloads."""
+
+        if share.quota_bytes is None:
+            return None
+
+        limit = share.quota_bytes
+        remaining = max(limit - usage, 0)
+        percent = 100.0 if limit == 0 else min((usage / limit) * 100.0, 100.0)
+        return {
+            "limit": limit,
+            "limit_display": format_file_size(limit),
+            "used": usage,
+            "used_display": format_file_size(usage),
+            "remaining": remaining,
+            "remaining_display": format_file_size(remaining),
+            "percent_used": percent,
+            "over": usage > limit,
+        }
+
+
+quota_manager = ShareQuotaManager()
+
+__all__ = [
+    "ShareQuotaManager",
+    "ShareQuotaExceededError",
+    "quota_manager",
+]

--- a/app/share_store.py
+++ b/app/share_store.py
@@ -1,0 +1,75 @@
+"""Persistent overrides for share settings such as quotas."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+STORE_PATH = Path("data/shares.json")
+
+
+def _default_store() -> Dict[str, Dict[str, Dict]]:
+    return {"shares": {}}
+
+
+def _load_store() -> Dict[str, Dict[str, Dict]]:
+    try:
+        if not STORE_PATH.exists():
+            return _default_store()
+
+        with STORE_PATH.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        if not isinstance(data, dict):
+            logger.warning("Invalid share store structure; resetting store")
+            return _default_store()
+
+        data.setdefault("shares", {})
+        if not isinstance(data["shares"], dict):
+            logger.warning("Invalid shares entry in store; resetting store")
+            data["shares"] = {}
+
+        return data
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to parse share store JSON: %s", exc)
+        return _default_store()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Unexpected error loading share store: %s", exc)
+        return _default_store()
+
+
+def _atomic_write(data: Dict[str, Dict[str, Dict]]):
+    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = STORE_PATH.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+    tmp_path.replace(STORE_PATH)
+
+
+def load_share_overrides() -> Dict[str, Dict[str, int]]:
+    """Return all stored share overrides."""
+
+    return _load_store().get("shares", {})
+
+
+def set_share_quota_override(share_name: str, quota_bytes: Optional[int]) -> None:
+    """Persist a quota override for the given share."""
+
+    store = _load_store()
+    shares = store.setdefault("shares", {})
+    if quota_bytes is None:
+        if share_name in shares:
+            del shares[share_name]
+    else:
+        shares[share_name] = {"quota_bytes": int(quota_bytes)}
+    _atomic_write(store)
+
+
+__all__ = [
+    "load_share_overrides",
+    "set_share_quota_override",
+]

--- a/app/user_store.py
+++ b/app/user_store.py
@@ -149,3 +149,38 @@ def add_registered_user(
     )
 
     return user, [rule]
+
+
+def list_registered_usernames() -> List[str]:
+    """Return the list of dynamically registered usernames."""
+
+    store = _load_store()
+    names: List[str] = []
+    for entry in store.get("users", []):
+        name = entry.get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def remove_registered_user(username: str) -> bool:
+    """Remove a dynamically registered user. Returns ``True`` if removed."""
+
+    store = _load_store()
+    users = store.get("users", [])
+    if not users:
+        return False
+
+    username_lower = username.lower()
+    filtered = [
+        entry
+        for entry in users
+        if str(entry.get("name", "")).lower() != username_lower
+    ]
+
+    if len(filtered) == len(users):
+        return False
+
+    store["users"] = filtered
+    _atomic_write(store)
+    return True

--- a/chfs.yaml
+++ b/chfs.yaml
@@ -13,6 +13,7 @@ server:
 shares:
   - name: "public"
     path: "C:\\chfs-data\\public"
+    quota: "50GB"
   - name: "home"
     path: "C:\\chfs-data\\home"
   - name: "temp"

--- a/scripts/server-control.ps1
+++ b/scripts/server-control.ps1
@@ -1,0 +1,229 @@
+<#
+.SYNOPSIS
+    Interactive Windows control panel for managing a local chfs-py server.
+
+.DESCRIPTION
+    Provides basic administrative operations exposed by the chfs-py REST API,
+    including inspecting server status, adjusting share quotas, and managing
+    dynamically registered users. All operations are executed against the
+    server running on the same machine (loopback only).
+
+.PARAMETER ServerUrl
+    Base URL of the running chfs-py server. Defaults to http://127.0.0.1:8080.
+
+.PARAMETER Username
+    Username for HTTP Basic authentication. If omitted you will be prompted.
+
+.PARAMETER Password
+    Password for HTTP Basic authentication. If omitted you will be prompted.
+#>
+param(
+    [string]$ServerUrl = "http://127.0.0.1:8080",
+    [string]$Username,
+    [string]$Password
+)
+
+function Get-BasicAuthHeader {
+    param(
+        [Parameter(Mandatory = $true)][string]$User,
+        [Parameter(Mandatory = $true)][string]$Pass
+    )
+
+    $pair = "$User:$Pass"
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($pair)
+    $token = [System.Convert]::ToBase64String($bytes)
+    return "Basic $token"
+}
+
+if (-not $Username -or -not $Password) {
+    $credential = Get-Credential -Message "Enter chfs-py administrator credentials"
+    if (-not $credential) {
+        Write-Error "Credentials are required."
+        exit 1
+    }
+    if (-not $Username) { $Username = $credential.UserName }
+    if (-not $Password) { $Password = $credential.GetNetworkCredential().Password }
+}
+
+$AuthHeader = Get-BasicAuthHeader -User $Username -Pass $Password
+
+function Invoke-ChfsApi {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [string]$BodyJson
+    )
+
+    $uri = "$ServerUrl$Path"
+    $headers = @{ Authorization = $AuthHeader }
+    if ($BodyJson) {
+        $headers['Content-Type'] = 'application/json'
+    }
+
+    try {
+        $response = Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $BodyJson -ErrorAction Stop
+        if ($response.detail) { return $response.detail }
+        return $response
+    }
+    catch {
+        throw "API request failed: $($_.Exception.Message)"
+    }
+}
+
+function Show-ServerStatus {
+    try {
+        $data = Invoke-ChfsApi -Method GET -Path '/api/admin/status'
+        if ($data.code -ne 0) {
+            $message = if ($data.msg) { $data.msg } else { 'Failed to retrieve status.' }
+            Write-Warning $message
+            return
+        }
+
+        $status = $data.data
+        Write-Host "`nServer:` $($status.server.host):$($status.server.port) ($($status.server.scheme))" -ForegroundColor Cyan
+        Write-Host " LAN URLs:" -ForegroundColor DarkGray
+        foreach ($url in $status.server.lan_urls) {
+            Write-Host "  - $url"
+        }
+
+        Write-Host " Shares:" -ForegroundColor DarkGray
+        foreach ($share in $status.shares) {
+            $quota = if ($share.quota_enabled) { $share.quota.limit_display } else { 'Unlimited' }
+            $used = $share.usage.display
+            Write-Host "  - $($share.name): $used used (limit: $quota)" -ForegroundColor Green
+        }
+
+        Write-Host " Users:" -ForegroundColor DarkGray
+        foreach ($user in $status.users) {
+            $source = if ($user.dynamic) { 'dynamic' } else { 'config' }
+            Write-Host "  - $($user.name) [$source]"
+        }
+    }
+    catch {
+        Write-Error $_
+    }
+}
+
+function Set-ShareQuota {
+    param(
+        [Parameter(Mandatory = $true)][string]$ShareName,
+        [Parameter(Mandatory = $true)][string]$Quota
+    )
+
+    try {
+        $body = @{ quota = $Quota } | ConvertTo-Json
+        $response = Invoke-ChfsApi -Method PUT -Path "/api/admin/shares/$([uri]::EscapeDataString($ShareName))/quota" -BodyJson $body
+        if ($response.code -ne 0) {
+            $message = if ($response.msg) { $response.msg } else { 'Failed to set quota.' }
+            Write-Warning $message
+            return
+        }
+        $share = $response.data.share
+        Write-Host "Quota for '$($share.name)' set to $($share.quotaDisplay)." -ForegroundColor Green
+    }
+    catch {
+        Write-Error $_
+    }
+}
+
+function Clear-ShareQuota {
+    param(
+        [Parameter(Mandatory = $true)][string]$ShareName
+    )
+
+    try {
+        $response = Invoke-ChfsApi -Method PUT -Path "/api/admin/shares/$([uri]::EscapeDataString($ShareName))/quota" -BodyJson '{}'
+        if ($response.code -ne 0) {
+            $message = if ($response.msg) { $response.msg } else { 'Failed to clear quota.' }
+            Write-Warning $message
+            return
+        }
+        Write-Host "Quota for '$ShareName' removed." -ForegroundColor Green
+    }
+    catch {
+        Write-Error $_
+    }
+}
+
+function List-Users {
+    try {
+        $response = Invoke-ChfsApi -Method GET -Path '/api/admin/users'
+        if ($response.code -ne 0) {
+            $message = if ($response.msg) { $response.msg } else { 'Failed to list users.' }
+            Write-Warning $message
+            return
+        }
+        $users = $response.data.users
+        if (-not $users -or $users.Count -eq 0) {
+            Write-Host 'No users registered.'
+            return
+        }
+
+        Write-Host "`nUsers:" -ForegroundColor Cyan
+        foreach ($user in $users) {
+            $source = if ($user.dynamic) { 'dynamic' } else { 'config' }
+            Write-Host " - $($user.name) [$source]"
+        }
+    }
+    catch {
+        Write-Error $_
+    }
+}
+
+function Remove-User {
+    param(
+        [Parameter(Mandatory = $true)][string]$UserName
+    )
+
+    try {
+        $response = Invoke-ChfsApi -Method DELETE -Path "/api/admin/users/$([uri]::EscapeDataString($UserName))"
+        if ($response.code -ne 0) {
+            $message = if ($response.msg) { $response.msg } else { 'Failed to remove user.' }
+            Write-Warning $message
+            return
+        }
+        Write-Host "Removed dynamic user '$UserName'." -ForegroundColor Green
+    }
+    catch {
+        Write-Error $_
+    }
+}
+
+Write-Host "chfs-py Windows Control Panel" -ForegroundColor Cyan
+Write-Host "Connected to $ServerUrl as $Username" -ForegroundColor DarkGray
+
+while ($true) {
+    Write-Host "`nAvailable actions:" -ForegroundColor Cyan
+    Write-Host "  [1] Show server status"
+    Write-Host "  [2] Set share quota"
+    Write-Host "  [3] Clear share quota"
+    Write-Host "  [4] List users"
+    Write-Host "  [5] Remove dynamic user"
+    Write-Host "  [0] Exit"
+
+    $choice = Read-Host "Select an option"
+    switch ($choice) {
+        '1' { Show-ServerStatus }
+        '2' {
+            $name = Read-Host 'Share name'
+            if ($name) {
+                $quota = Read-Host 'Quota (e.g. 10GB)'
+                if ($quota) { Set-ShareQuota -ShareName $name -Quota $quota }
+                else { Write-Warning 'Quota value is required.' }
+            }
+        }
+        '3' {
+            $name = Read-Host 'Share name'
+            if ($name) { Clear-ShareQuota -ShareName $name }
+        }
+        '4' { List-Users }
+        '5' {
+            $user = Read-Host 'Username'
+            if ($user) { Remove-User -UserName $user }
+        }
+        '0' { break }
+        default { Write-Warning 'Invalid option.' }
+    }
+}
+
+Write-Host 'Goodbye.' -ForegroundColor DarkGray

--- a/templates/index.html
+++ b/templates/index.html
@@ -463,6 +463,10 @@
                      class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4"
                      x-text="controlPanelError"></div>
 
+                <div x-show="controlPanelNotice"
+                     class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg mb-4"
+                     x-text="controlPanelNotice"></div>
+
                 <div x-show="!controlPanelLoading && controlPanelData" class="space-y-6 max-h-[70vh] overflow-y-auto pr-1">
                     <section class="bg-gray-50 border border-gray-200 rounded-lg p-4">
                         <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-3">
@@ -560,6 +564,7 @@
                                         <th class="px-3 py-2 text-left font-medium text-gray-600">Path</th>
                                         <th class="px-3 py-2 text-left font-medium text-gray-600">Status</th>
                                         <th class="px-3 py-2 text-left font-medium text-gray-600">Disk</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-600">Storage</th>
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-gray-100">
@@ -600,10 +605,97 @@
                                                 </template>
                                                 <p x-show="!share.disk" class="text-gray-400">Disk usage unavailable</p>
                                             </td>
+                                            <td class="px-3 py-2 text-xs text-gray-700 space-y-2">
+                                                <div>
+                                                    <span class="font-medium text-gray-700">Used:</span>
+                                                    <span x-text="share.usage?.display || '0 B'"></span>
+                                                </div>
+                                                <template x-if="share.quota_enabled">
+                                                    <div class="space-y-1">
+                                                        <div>
+                                                            <span class="font-medium text-gray-700">Limit:</span>
+                                                            <span x-text="share.quota?.limit_display || '—'"></span>
+                                                        </div>
+                                                        <div>
+                                                            <span class="font-medium text-gray-700">Remaining:</span>
+                                                            <span x-text="share.quota?.remaining_display || '0 B'"></span>
+                                                        </div>
+                                                        <div>
+                                                            <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                                                                <div class="h-2" :class="share.quota?.over ? 'bg-red-500' : 'bg-blue-600'"
+                                                                     :style="`width: ${Math.min(share.quota?.percent_used ?? 0, 100)}%`"></div>
+                                                            </div>
+                                                            <div class="text-[10px] text-gray-500 mt-1">
+                                                                <span x-text="(share.quota?.percent_used ?? 0).toFixed(1)"></span>% used
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </template>
+                                                <p x-show="!share.quota_enabled" class="text-gray-400">No quota limit</p>
+                                                <div class="flex flex-wrap gap-2 pt-1">
+                                                    <button @click="promptShareQuota(share)"
+                                                            class="text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 transition-colors">
+                                                        Set quota
+                                                    </button>
+                                                    <button x-show="share.quota_enabled"
+                                                            @click="clearShareQuota(share)"
+                                                            class="text-xs px-2 py-1 bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors">
+                                                        Remove limit
+                                                    </button>
+                                                </div>
+                                            </td>
                                         </tr>
                                     </template>
                                     <tr x-show="(controlPanelData?.shares || []).length === 0">
-                                        <td colspan="4" class="px-3 py-4 text-center text-gray-500">No shares configured.</td>
+                                        <td colspan="5" class="px-3 py-4 text-center text-gray-500">No shares configured.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+
+                    <section class="bg-white border border-gray-200 rounded-lg p-4">
+                        <div class="flex items-center justify-between mb-3">
+                            <h4 class="text-lg font-semibold text-gray-800">User Accounts</h4>
+                            <span class="text-xs text-gray-500"
+                                  x-text="`Total: ${(controlPanelData?.users || []).length}`"></span>
+                        </div>
+                        <p class="text-sm text-gray-600 mb-3">
+                            Users registered via the control panel can be removed from here. Accounts defined in
+                            the configuration file are read-only.
+                        </p>
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full text-sm">
+                                <thead>
+                                    <tr class="text-left text-gray-600 border-b border-gray-200">
+                                        <th class="px-3 py-2">Username</th>
+                                        <th class="px-3 py-2">Source</th>
+                                        <th class="px-3 py-2">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100">
+                                    <template x-for="user in (controlPanelData?.users || [])" :key="user.name">
+                                        <tr>
+                                            <td class="px-3 py-2 font-medium text-gray-800" x-text="user.name"></td>
+                                            <td class="px-3 py-2">
+                                                <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs"
+                                                      :class="user.dynamic ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'">
+                                                    <i :class="user.dynamic ? 'fas fa-user-plus' : 'fas fa-file-lines'"></i>
+                                                    <span x-text="user.dynamic ? 'Dynamic' : 'Config file'"></span>
+                                                </span>
+                                            </td>
+                                            <td class="px-3 py-2">
+                                                <button x-show="user.dynamic"
+                                                        @click="removeUser(user.name)"
+                                                        class="text-xs px-3 py-1 bg-red-100 text-red-700 rounded hover:bg-red-200 transition-colors">
+                                                    Remove
+                                                </button>
+                                                <span x-show="!user.dynamic" class="text-xs text-gray-400">Managed externally</span>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                    <tr x-show="!(controlPanelData?.users || []).length">
+                                        <td colspan="3" class="px-3 py-4 text-center text-gray-500">No users available.</td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -716,6 +808,7 @@
                 showControlPanel: false,
                 controlPanelLoading: false,
                 controlPanelError: '',
+                controlPanelNotice: '',
                 controlPanelData: null,
                 controlPanelFetchedAt: null,
 
@@ -944,8 +1037,101 @@
                     await this.loadControlPanel(true);
                 },
 
+                async updateShareQuota(name, payload) {
+                    if (!this.ensureAuthenticated(false)) {
+                        return;
+                    }
+                    this.controlPanelError = '';
+                    this.controlPanelNotice = '';
+
+                    try {
+                        const response = await fetch(`/api/admin/shares/${encodeURIComponent(name)}/quota`, {
+                            method: 'PUT',
+                            headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+                            body: JSON.stringify(payload || {})
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payloadData = this.parseApiResponse(await response.json());
+                        if (response.ok && payloadData.code === 0) {
+                            this.controlPanelNotice = `Quota updated for ${name}.`;
+                            await this.refreshControlPanel();
+                        } else {
+                            this.controlPanelError = payloadData?.msg || 'Failed to update share quota.';
+                        }
+                    } catch (e) {
+                        this.controlPanelError = 'Failed to update share quota: ' + e.message;
+                    }
+                },
+
+                async promptShareQuota(share) {
+                    if (!share || !share.name) {
+                        return;
+                    }
+                    const current = share.quota?.limit_display || '';
+                    const value = window.prompt('Enter a quota (e.g. 10GB). Leave blank to remove the limit.', current);
+                    if (value === null) {
+                        return;
+                    }
+                    const trimmed = value.trim();
+                    if (!trimmed) {
+                        await this.clearShareQuota(share);
+                        return;
+                    }
+                    await this.updateShareQuota(share.name, { quota: trimmed });
+                },
+
+                async clearShareQuota(share) {
+                    if (!share || !share.name) {
+                        return;
+                    }
+                    if (!window.confirm(`Remove the quota limit for "${share.name}"?`)) {
+                        return;
+                    }
+                    await this.updateShareQuota(share.name, {});
+                },
+
+                async removeUser(username) {
+                    if (!username) {
+                        return;
+                    }
+                    if (!window.confirm(`Remove user "${username}"?`)) {
+                        return;
+                    }
+
+                    this.controlPanelError = '';
+                    this.controlPanelNotice = '';
+
+                    try {
+                        const response = await fetch(`/api/admin/users/${encodeURIComponent(username)}`, {
+                            method: 'DELETE',
+                            headers: this.buildHeaders()
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            this.controlPanelNotice = `Removed user ${username}.`;
+                            await this.refreshControlPanel();
+                        } else {
+                            this.controlPanelError = payload?.msg || 'Failed to remove user.';
+                        }
+                    } catch (e) {
+                        this.controlPanelError = 'Failed to remove user: ' + e.message;
+                    }
+                },
+
                 closeControlPanel() {
                     this.showControlPanel = false;
+                    this.controlPanelNotice = '';
                 },
 
                 parseApiResponse(data) {


### PR DESCRIPTION
## Summary
- add share quota parsing/enforcement with persistent overrides and localhost-protected admin APIs
- enhance the control panel UI with quota visuals, user management actions, and a Windows PowerShell console
- document the new features and update sample configuration for per-share quotas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5fd6a19148327aa7921e6234a3778