### PR TITLE
Add direct user-to-user transfer feature

### DIFF
--- a/app/direct_transfer.py
+++ b/app/direct_transfer.py
@@ -1,0 +1,355 @@
+"""Direct transfer management between users."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import UploadFile
+
+from .utils import generate_short_id
+
+logger = logging.getLogger(__name__)
+
+
+class DirectTransferError(Exception):
+    """Base exception for direct transfer operations."""
+
+    def __init__(self, message: str, *, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass
+class DirectTransferEntry:
+    """Represents a pending direct transfer entry."""
+
+    id: str
+    sender: str
+    recipient: str
+    filename: str
+    stored_filename: str
+    size: int
+    content_type: str
+    created_at: float
+    expires_at: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise entry for persistence."""
+
+        return {
+            "id": self.id,
+            "sender": self.sender,
+            "recipient": self.recipient,
+            "filename": self.filename,
+            "stored_filename": self.stored_filename,
+            "size": self.size,
+            "content_type": self.content_type,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+        }
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        """Serialise entry for API responses."""
+
+        return {
+            "id": self.id,
+            "sender": self.sender,
+            "recipient": self.recipient,
+            "filename": self.filename,
+            "size": self.size,
+            "contentType": self.content_type,
+            "createdAt": self.created_at,
+            "expiresAt": self.expires_at,
+            "downloadUrl": f"/api/direct-transfer/download/{self.id}",
+        }
+
+
+class DirectTransferStore:
+    """Persists pending direct transfer entries and payloads."""
+
+    def __init__(self, base_dir: Path | None = None):
+        self.base_dir = (base_dir or Path("data/direct_transfers")).resolve()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.meta_path = self.base_dir / "transfers.json"
+        self._lock = asyncio.Lock()
+        self._entries: Dict[str, DirectTransferEntry] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load existing metadata from disk."""
+
+        if not self.meta_path.exists():
+            return
+
+        try:
+            with self.meta_path.open("r", encoding="utf-8") as f:
+                data = json.load(f) or {}
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse direct transfer metadata: %s", exc)
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Unexpected error loading transfer metadata: %s", exc)
+            return
+
+        entries = data.get("transfers", [])
+        if not isinstance(entries, list):
+            logger.warning("Invalid transfers structure in metadata file")
+            return
+
+        loaded = 0
+        for item in entries:
+            if not isinstance(item, dict):
+                continue
+            try:
+                entry = DirectTransferEntry(
+                    id=item["id"],
+                    sender=item["sender"],
+                    recipient=item["recipient"],
+                    filename=item["filename"],
+                    stored_filename=item["stored_filename"],
+                    size=int(item["size"]),
+                    content_type=item.get("content_type", "application/octet-stream"),
+                    created_at=float(item["created_at"]),
+                    expires_at=(float(item["expires_at"]) if item.get("expires_at") else None),
+                )
+            except (KeyError, TypeError, ValueError):
+                logger.warning("Skipping invalid transfer metadata entry: %s", item)
+                continue
+
+            payload_path = self.base_dir / entry.stored_filename
+            if not payload_path.exists():
+                logger.info("Removing metadata for missing transfer payload: %s", entry.id)
+                continue
+
+            self._entries[entry.id] = entry
+            loaded += 1
+
+        if loaded:
+            logger.info("Loaded %d pending direct transfers", loaded)
+
+    def _save_locked(self) -> None:
+        """Persist current metadata to disk. Caller must hold the lock."""
+
+        data = {"transfers": [entry.to_dict() for entry in self._entries.values()]}
+        tmp_path = self.meta_path.with_suffix(".tmp")
+        self.meta_path.parent.mkdir(parents=True, exist_ok=True)
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        tmp_path.replace(self.meta_path)
+
+    def _delete_file(self, path: Path) -> None:
+        """Delete a payload file safely."""
+
+        try:
+            path.unlink(missing_ok=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to delete transfer payload %s: %s", path, exc)
+
+    def _prune_locked(self) -> None:
+        """Remove expired or missing entries. Caller must hold the lock."""
+
+        now = time.time()
+        removed = False
+        for transfer_id, entry in list(self._entries.items()):
+            should_remove = False
+            if entry.expires_at is not None and entry.expires_at < now:
+                should_remove = True
+            else:
+                payload_path = self.base_dir / entry.stored_filename
+                if not payload_path.exists():
+                    should_remove = True
+
+            if should_remove:
+                removed = True
+                logger.info("Pruning expired or missing transfer %s", transfer_id)
+                self._entries.pop(transfer_id, None)
+                self._delete_file(self.base_dir / entry.stored_filename)
+
+        if removed:
+            self._save_locked()
+
+    def _allocate_locked(self, original_filename: str) -> Tuple[str, str]:
+        """Allocate a unique transfer identifier and stored filename."""
+
+        suffix = Path(original_filename or "transfer").suffix
+        if not suffix:
+            suffix = ".bin"
+
+        for _ in range(64):
+            transfer_id = generate_short_id(12)
+            stored_filename = f"{transfer_id}{suffix}"
+            if transfer_id in self._entries:
+                continue
+            if (self.base_dir / stored_filename).exists():
+                continue
+            return transfer_id, stored_filename
+
+        raise DirectTransferError("Unable to allocate a transfer identifier", status_code=500)
+
+    async def _write_upload_to_path(
+        self,
+        upload_file: UploadFile,
+        destination: Path,
+        *,
+        max_size: Optional[int] = None,
+    ) -> int:
+        """Write an upload file to the destination path and return bytes written."""
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        await upload_file.seek(0)
+
+        size = 0
+        try:
+            with destination.open("wb") as output:
+                while True:
+                    chunk = await upload_file.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    if max_size is not None and size > max_size:
+                        raise DirectTransferError(
+                            f"File too large (max: {max_size} bytes)",
+                            status_code=413,
+                        )
+                    output.write(chunk)
+        finally:
+            await upload_file.close()
+
+        return size
+
+    async def create_transfer(
+        self,
+        sender: str,
+        recipient: str,
+        upload_file: UploadFile,
+        *,
+        expires_in: Optional[int] = None,
+        max_size: Optional[int] = None,
+    ) -> DirectTransferEntry:
+        """Create a direct transfer entry and persist payload."""
+
+        if not upload_file:
+            raise DirectTransferError("No file uploaded for transfer")
+
+        tmp_name = f"tmp-{generate_short_id(10)}"
+        tmp_path = self.base_dir / tmp_name
+
+        try:
+            size = await self._write_upload_to_path(
+                upload_file,
+                tmp_path,
+                max_size=max_size,
+            )
+        except DirectTransferError:
+            self._delete_file(tmp_path)
+            raise
+        except Exception as exc:
+            self._delete_file(tmp_path)
+            logger.error("Failed to store direct transfer payload: %s", exc)
+            raise DirectTransferError("Failed to store uploaded file", status_code=500) from exc
+
+        created_at = time.time()
+        expires_at = created_at + expires_in if expires_in and expires_in > 0 else None
+        content_type = upload_file.content_type or "application/octet-stream"
+
+        async with self._lock:
+            self._prune_locked()
+            transfer_id, stored_filename = self._allocate_locked(upload_file.filename or "transfer")
+            final_path = self.base_dir / stored_filename
+            tmp_path.replace(final_path)
+
+            entry = DirectTransferEntry(
+                id=transfer_id,
+                sender=sender,
+                recipient=recipient,
+                filename=upload_file.filename or stored_filename,
+                stored_filename=stored_filename,
+                size=size,
+                content_type=content_type,
+                created_at=created_at,
+                expires_at=expires_at,
+            )
+
+            self._entries[entry.id] = entry
+            self._save_locked()
+
+        logger.info("Created direct transfer %s from %s to %s", entry.id, sender, recipient)
+        return entry
+
+    async def list_transfers(self, username: str, direction: str) -> List[Dict[str, Any]]:
+        """List pending transfers for a user in the given direction."""
+
+        direction = direction.lower()
+        if direction not in {"incoming", "outgoing"}:
+            raise DirectTransferError("Invalid transfer direction", status_code=400)
+
+        async with self._lock:
+            self._prune_locked()
+            if direction == "incoming":
+                entries = [entry.to_public_dict() for entry in self._entries.values() if entry.recipient == username]
+            else:
+                entries = [entry.to_public_dict() for entry in self._entries.values() if entry.sender == username]
+
+        entries.sort(key=lambda item: item.get("createdAt", 0), reverse=True)
+        return entries
+
+    async def prepare_download(self, transfer_id: str, username: str) -> Tuple[Path, DirectTransferEntry]:
+        """Prepare a transfer for download and remove it from the queue."""
+
+        async with self._lock:
+            self._prune_locked()
+            entry = self._entries.get(transfer_id)
+            if not entry:
+                raise DirectTransferError("Transfer not found", status_code=404)
+
+            if entry.recipient != username:
+                raise DirectTransferError("You do not have access to this transfer", status_code=403)
+
+            payload_path = self.base_dir / entry.stored_filename
+            if not payload_path.exists():
+                self._entries.pop(transfer_id, None)
+                self._save_locked()
+                raise DirectTransferError("Transfer payload is no longer available", status_code=404)
+
+            self._entries.pop(transfer_id, None)
+            self._save_locked()
+
+        return payload_path, entry
+
+    def cleanup_after_download(self, entry: DirectTransferEntry) -> None:
+        """Cleanup payload after a download completes."""
+
+        self._delete_file(self.base_dir / entry.stored_filename)
+        logger.info(
+            "Direct transfer %s delivered to %s", entry.id, entry.recipient
+        )
+
+    async def delete_transfer(self, transfer_id: str, username: str) -> DirectTransferEntry:
+        """Remove a transfer without downloading it."""
+
+        async with self._lock:
+            self._prune_locked()
+            entry = self._entries.get(transfer_id)
+            if not entry:
+                raise DirectTransferError("Transfer not found", status_code=404)
+
+            if username not in {entry.sender, entry.recipient}:
+                raise DirectTransferError("You do not have access to this transfer", status_code=403)
+
+            self._entries.pop(transfer_id, None)
+            self._save_locked()
+
+        self._delete_file(self.base_dir / entry.stored_filename)
+        logger.info("Direct transfer %s removed by %s", transfer_id, username)
+        return entry
+
+
+direct_transfer_store = DirectTransferStore()
+
+__all__ = ["direct_transfer_store", "DirectTransferStore", "DirectTransferError"]

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,6 +50,11 @@
                                 <i class="fas fa-share-alt"></i>
                                 <span class="hidden sm:inline">Share Text</span>
                             </button>
+                            <button @click="openDirectTransfer()"
+                                    class="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
+                                <i class="fas fa-paper-plane"></i>
+                                <span class="hidden sm:inline">Direct Transfer</span>
+                            </button>
                             <button @click="openControlPanel()"
                                     class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors">
                                 <i class="fas fa-sliders-h"></i>
@@ -382,14 +387,14 @@
         <div x-show="showTextShare" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
             <div class="bg-white rounded-lg max-w-2xl w-full p-6" @click.away="showTextShare = false">
                 <h3 class="text-lg font-semibold mb-4">Share Text</h3>
-                <textarea x-model="shareText" placeholder="Enter text to share..." 
+                <textarea x-model="shareText" placeholder="Enter text to share..."
                           class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent h-32 resize-none"></textarea>
                 <div x-show="shareUrl" class="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg">
                     <p class="text-sm text-green-800 mb-2">Share URL created:</p>
                     <div class="flex items-center gap-2">
-                        <input type="text" :value="shareUrl" readonly 
+                        <input type="text" :value="shareUrl" readonly
                                class="flex-1 bg-white border border-green-300 rounded px-2 py-1 text-sm">
-                        <button @click="copyToClipboard(shareUrl)" 
+                        <button @click="copyToClipboard(shareUrl)"
                                 class="bg-green-600 text-white px-3 py-1 rounded text-sm hover:bg-green-700 transition-colors">
                             Copy
                         </button>
@@ -399,11 +404,160 @@
                     <button @click="showTextShare = false" class="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors">
                         Cancel
                     </button>
-                    <button @click="createTextShare()" 
+                    <button @click="createTextShare()"
                             :disabled="!shareText.trim()"
                             class="bg-purple-600 text-white px-4 py-2 rounded-lg hover:bg-purple-700 disabled:opacity-50 transition-colors">
                         Create Share
                     </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Direct Transfer Modal -->
+        <div x-show="showDirectTransfer" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+            <div class="bg-white rounded-lg max-w-3xl w-full p-6 space-y-4" @click.away="closeDirectTransfer()">
+                <div class="flex items-start justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900">Direct Transfer</h3>
+                        <p class="text-sm text-gray-500">Send files directly to another user on this server.</p>
+                    </div>
+                    <button @click="closeDirectTransfer()" class="text-gray-500 hover:text-gray-700">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+
+                <div x-show="directTransferSuccess" class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg" x-text="directTransferSuccess"></div>
+                <div x-show="directTransferError" class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg" x-text="directTransferError"></div>
+                <div x-show="directTransferListError" class="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded-lg" x-text="directTransferListError"></div>
+
+                <form class="space-y-4" @submit.prevent="sendDirectTransfer()">
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Recipient</label>
+                            <select x-model="directTransferRecipient"
+                                    :disabled="directTransferRecipientsLoading || directTransferRecipients.length === 0"
+                                    class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-orange-500 focus:border-transparent">
+                                <option value="" disabled>Select recipient</option>
+                                <template x-for="recipient in directTransferRecipients" :key="`recipient-${recipient}`">
+                                    <option :value="recipient" x-text="recipient"></option>
+                                </template>
+                            </select>
+                            <p x-show="directTransferRecipientsLoading" class="text-xs text-gray-500 mt-1">Loading users…</p>
+                            <p x-show="!directTransferRecipientsLoading && directTransferRecipients.length === 0" class="text-xs text-gray-500 mt-1">No other users are currently available.</p>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">File</label>
+                            <input type="file" @change="handleDirectTransferFile($event)" x-ref="directTransferFileInput"
+                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-orange-500 focus:border-transparent">
+                            <p x-show="directTransferFile" class="text-xs text-gray-600 mt-2 flex items-center gap-2">
+                                <span class="font-medium" x-text="directTransferFile?.name"></span>
+                                <span x-text="formatFileSize(directTransferFile?.size || 0)" class="text-gray-500"></span>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <button type="button" @click="closeDirectTransfer()" class="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors">Cancel</button>
+                        <button type="submit"
+                                :disabled="directTransferSending || !directTransferRecipient || !directTransferFile"
+                                class="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-lg disabled:opacity-50 transition-colors">
+                            <span x-show="!directTransferSending">Send</span>
+                            <span x-show="directTransferSending">Sending…</span>
+                        </button>
+                    </div>
+                </form>
+
+                <div class="border-t border-gray-200 pt-4">
+                    <div class="flex flex-wrap items-center gap-3 mb-4">
+                        <div class="flex gap-2">
+                            <button type="button"
+                                    @click="directTransferTab = 'incoming'"
+                                    :class="directTransferTab === 'incoming' ? 'bg-orange-600 text-white' : 'bg-gray-200 text-gray-700'"
+                                    class="px-3 py-1 rounded-lg text-sm font-medium transition-colors">
+                                Incoming
+                            </button>
+                            <button type="button"
+                                    @click="directTransferTab = 'outgoing'"
+                                    :class="directTransferTab === 'outgoing' ? 'bg-orange-600 text-white' : 'bg-gray-200 text-gray-700'"
+                                    class="px-3 py-1 rounded-lg text-sm font-medium transition-colors">
+                                Sent
+                            </button>
+                        </div>
+                        <button type="button" @click="refreshDirectTransferLists()"
+                                class="ml-auto bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-1 rounded-lg text-sm transition-colors">
+                            Refresh
+                        </button>
+                    </div>
+
+                    <div x-show="directTransferListLoading" class="bg-blue-50 border border-blue-100 text-blue-700 px-4 py-3 rounded-lg">
+                        <i class="fas fa-circle-notch fa-spin mr-2"></i>
+                        Loading transfers…
+                    </div>
+
+                    <div x-show="!directTransferListLoading && directTransferTab === 'incoming'" class="space-y-3">
+                        <template x-if="directTransferIncoming.length > 0">
+                            <ul class="space-y-3">
+                                <template x-for="item in directTransferIncoming" :key="`incoming-${item.id}`">
+                                    <li class="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                            <div>
+                                                <p class="font-medium text-gray-800" x-text="item.filename"></p>
+                                                <p class="text-sm text-gray-600">
+                                                    From <span class="font-semibold" x-text="item.sender"></span>
+                                                    • <span x-text="formatFileSize(item.size)"></span>
+                                                    • <span x-text="formatDate(item.createdAt)"></span>
+                                                    <span x-show="item.expiresAt" class="ml-2 text-orange-600">
+                                                        Expires <span x-text="formatDate(item.expiresAt)"></span>
+                                                    </span>
+                                                </p>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <button @click="downloadDirectTransfer(item)"
+                                                        class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg text-sm transition-colors">
+                                                    Download
+                                                </button>
+                                                <button @click="deleteDirectTransfer(item, 'incoming')"
+                                                        class="bg-gray-200 hover:bg-gray-300 text-gray-700 px-3 py-2 rounded-lg text-sm transition-colors">
+                                                    Decline
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </li>
+                                </template>
+                            </ul>
+                        </template>
+                        <p x-show="directTransferIncoming.length === 0" class="text-sm text-gray-500">No incoming transfers.</p>
+                    </div>
+
+                    <div x-show="!directTransferListLoading && directTransferTab === 'outgoing'" class="space-y-3">
+                        <template x-if="directTransferOutgoing.length > 0">
+                            <ul class="space-y-3">
+                                <template x-for="item in directTransferOutgoing" :key="`outgoing-${item.id}`">
+                                    <li class="border border-gray-200 rounded-lg p-4">
+                                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                            <div>
+                                                <p class="font-medium text-gray-800" x-text="item.filename"></p>
+                                                <p class="text-sm text-gray-600">
+                                                    To <span class="font-semibold" x-text="item.recipient"></span>
+                                                    • <span x-text="formatFileSize(item.size)"></span>
+                                                    • <span x-text="formatDate(item.createdAt)"></span>
+                                                    <span x-show="item.expiresAt" class="ml-2 text-orange-600">
+                                                        Expires <span x-text="formatDate(item.expiresAt)"></span>
+                                                    </span>
+                                                </p>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <button @click="deleteDirectTransfer(item, 'outgoing')"
+                                                        class="bg-gray-200 hover:bg-gray-300 text-gray-700 px-3 py-2 rounded-lg text-sm transition-colors">
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </li>
+                                </template>
+                            </ul>
+                        </template>
+                        <p x-show="directTransferOutgoing.length === 0" class="text-sm text-gray-500">No pending sent transfers.</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -804,6 +958,7 @@
                 showUpload: false,
                 showNewFolder: false,
                 showTextShare: false,
+                showDirectTransfer: false,
                 showRename: false,
                 showControlPanel: false,
                 controlPanelLoading: false,
@@ -820,6 +975,20 @@
                 renameValue: '',
                 renameTarget: null,
                 uploading: false,
+
+                // Direct transfer state
+                directTransferRecipients: [],
+                directTransferRecipientsLoading: false,
+                directTransferRecipient: '',
+                directTransferFile: null,
+                directTransferSending: false,
+                directTransferSuccess: '',
+                directTransferError: '',
+                directTransferListError: '',
+                directTransferIncoming: [],
+                directTransferOutgoing: [],
+                directTransferListLoading: false,
+                directTransferTab: 'incoming',
 
                 init() {
                     const savedUser = localStorage.getItem('chfsAuthUser');
@@ -1176,6 +1345,7 @@
                                 this.currentRoot = roots[0] || '';
                                 this.currentPath = '';
                             }
+                            await this.refreshDirectTransferLists();
                             return true;
                         }
 
@@ -1247,6 +1417,7 @@
                     this.showUpload = false;
                     this.showNewFolder = false;
                     this.showTextShare = false;
+                    this.showDirectTransfer = false;
                     this.showRename = false;
                     this.showControlPanel = false;
                     this.uploadFiles = [];
@@ -1255,6 +1426,18 @@
                     this.shareUrl = '';
                     this.renameTarget = null;
                     this.renameValue = '';
+                    this.directTransferRecipients = [];
+                    this.directTransferRecipientsLoading = false;
+                    this.directTransferRecipient = '';
+                    this.directTransferFile = null;
+                    this.directTransferSending = false;
+                    this.directTransferSuccess = '';
+                    this.directTransferError = '';
+                    this.directTransferListError = '';
+                    this.directTransferIncoming = [];
+                    this.directTransferOutgoing = [];
+                    this.directTransferListLoading = false;
+                    this.directTransferTab = 'incoming';
                     this.controlPanelData = null;
                     this.controlPanelError = '';
                     this.controlPanelFetchedAt = null;
@@ -1283,6 +1466,7 @@
                     this.showUpload = false;
                     this.showNewFolder = false;
                     this.showTextShare = false;
+                    this.showDirectTransfer = false;
                     this.showRename = false;
                     this.showControlPanel = false;
                     this.uploadFiles = [];
@@ -1291,6 +1475,18 @@
                     this.shareUrl = '';
                     this.renameTarget = null;
                     this.renameValue = '';
+                    this.directTransferRecipients = [];
+                    this.directTransferRecipientsLoading = false;
+                    this.directTransferRecipient = '';
+                    this.directTransferFile = null;
+                    this.directTransferSending = false;
+                    this.directTransferSuccess = '';
+                    this.directTransferError = '';
+                    this.directTransferListError = '';
+                    this.directTransferIncoming = [];
+                    this.directTransferOutgoing = [];
+                    this.directTransferListLoading = false;
+                    this.directTransferTab = 'incoming';
                     this.controlPanelData = null;
                     this.controlPanelError = '';
                     this.controlPanelFetchedAt = null;
@@ -1616,6 +1812,248 @@
                         }
                     } catch (e) {
                         alert('Text share failed: ' + e.message);
+                    }
+                },
+
+                async openDirectTransfer() {
+                    if (!this.ensureAuthenticated()) {
+                        return;
+                    }
+                    this.directTransferError = '';
+                    this.directTransferSuccess = '';
+                    this.directTransferListError = '';
+                    this.directTransferFile = null;
+                    this.directTransferTab = 'incoming';
+                    this.showDirectTransfer = true;
+                    if (this.$refs.directTransferFileInput) {
+                        this.$refs.directTransferFileInput.value = '';
+                    }
+                    await Promise.all([
+                        this.loadDirectTransferRecipients(),
+                        this.refreshDirectTransferLists(),
+                    ]);
+                },
+
+                closeDirectTransfer() {
+                    this.showDirectTransfer = false;
+                    this.directTransferSending = false;
+                    this.directTransferRecipientsLoading = false;
+                    this.directTransferFile = null;
+                    this.directTransferError = '';
+                    this.directTransferSuccess = '';
+                    this.directTransferListError = '';
+                    if (this.$refs.directTransferFileInput) {
+                        this.$refs.directTransferFileInput.value = '';
+                    }
+                },
+
+                handleDirectTransferFile(event) {
+                    const files = event?.target?.files;
+                    this.directTransferFile = files && files[0] ? files[0] : null;
+                },
+
+                async loadDirectTransferRecipients() {
+                    if (!this.ensureAuthenticated(false)) {
+                        return;
+                    }
+                    this.directTransferRecipientsLoading = true;
+                    try {
+                        const response = await fetch('/api/direct-transfer/recipients', {
+                            headers: this.buildHeaders(),
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            const names = Array.isArray(payload.data?.recipients) ? payload.data.recipients : [];
+                            this.directTransferRecipients = names;
+                            if (!names.includes(this.directTransferRecipient)) {
+                                this.directTransferRecipient = names[0] || '';
+                            }
+                        } else {
+                            this.directTransferListError = payload?.msg || 'Failed to load recipients.';
+                        }
+                    } catch (e) {
+                        this.directTransferListError = 'Failed to load recipients: ' + e.message;
+                    } finally {
+                        this.directTransferRecipientsLoading = false;
+                    }
+                },
+
+                async fetchDirectTransferList(direction) {
+                    try {
+                        const response = await fetch(`/api/direct-transfer/list?direction=${encodeURIComponent(direction)}`, {
+                            headers: this.buildHeaders(),
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return [];
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            const transfers = Array.isArray(payload.data?.transfers) ? payload.data.transfers : [];
+                            return transfers;
+                        }
+
+                        throw new Error(payload?.msg || 'Failed to load transfers.');
+                    } catch (e) {
+                        throw new Error(e.message || 'Failed to load transfers.');
+                    }
+                },
+
+                async refreshDirectTransferLists() {
+                    if (!this.ensureAuthenticated(false)) {
+                        this.directTransferIncoming = [];
+                        this.directTransferOutgoing = [];
+                        return;
+                    }
+                    this.directTransferListLoading = true;
+                    this.directTransferListError = '';
+                    try {
+                        const [incoming, outgoing] = await Promise.all([
+                            this.fetchDirectTransferList('incoming'),
+                            this.fetchDirectTransferList('outgoing'),
+                        ]);
+                        this.directTransferIncoming = incoming;
+                        this.directTransferOutgoing = outgoing;
+                    } catch (e) {
+                        this.directTransferListError = e.message || 'Failed to load transfers.';
+                    } finally {
+                        this.directTransferListLoading = false;
+                    }
+                },
+
+                async sendDirectTransfer() {
+                    if (!this.ensureAuthenticated()) {
+                        return;
+                    }
+                    if (!this.directTransferRecipient) {
+                        this.directTransferError = 'Please choose a recipient.';
+                        return;
+                    }
+                    if (!this.directTransferFile) {
+                        this.directTransferError = 'Please select a file to send.';
+                        return;
+                    }
+
+                    this.directTransferError = '';
+                    this.directTransferSuccess = '';
+                    this.directTransferSending = true;
+
+                    const formData = new FormData();
+                    formData.append('recipient', this.directTransferRecipient);
+                    formData.append('file', this.directTransferFile);
+
+                    try {
+                        const response = await fetch('/api/direct-transfer/send', {
+                            method: 'POST',
+                            headers: this.buildHeaders(),
+                            body: formData,
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            const filename = payload.data?.transfer?.filename || (this.directTransferFile?.name || 'file');
+                            this.directTransferSuccess = `Sent ${filename} to ${this.directTransferRecipient}.`;
+                            this.directTransferFile = null;
+                            if (this.$refs.directTransferFileInput) {
+                                this.$refs.directTransferFileInput.value = '';
+                            }
+                            await this.refreshDirectTransferLists();
+                        } else {
+                            this.directTransferError = payload?.msg || 'Failed to send transfer.';
+                        }
+                    } catch (e) {
+                        this.directTransferError = 'Failed to send transfer: ' + e.message;
+                    } finally {
+                        this.directTransferSending = false;
+                    }
+                },
+
+                async downloadDirectTransfer(item) {
+                    if (!item || !item.id) {
+                        return;
+                    }
+                    if (!this.ensureAuthenticated()) {
+                        return;
+                    }
+
+                    this.directTransferError = '';
+
+                    try {
+                        const response = await fetch(`/api/direct-transfer/download/${encodeURIComponent(item.id)}`, {
+                            headers: this.buildHeaders(),
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        if (!response.ok) {
+                            const payload = this.parseApiResponse(await response.json());
+                            this.directTransferError = payload?.msg || 'Failed to download transfer.';
+                            return;
+                        }
+
+                        const blob = await response.blob();
+                        const url = URL.createObjectURL(blob);
+                        const link = document.createElement('a');
+                        link.href = url;
+                        link.download = item.filename || 'download';
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                        URL.revokeObjectURL(url);
+                        this.directTransferSuccess = `Downloaded ${item.filename || 'file'}.`;
+                        await this.refreshDirectTransferLists();
+                    } catch (e) {
+                        this.directTransferError = 'Failed to download transfer: ' + e.message;
+                    }
+                },
+
+                async deleteDirectTransfer(item, direction = 'incoming') {
+                    if (!item || !item.id) {
+                        return;
+                    }
+                    if (!this.ensureAuthenticated()) {
+                        return;
+                    }
+
+                    this.directTransferError = '';
+
+                    try {
+                        const response = await fetch(`/api/direct-transfer/${encodeURIComponent(item.id)}`, {
+                            method: 'DELETE',
+                            headers: this.buildHeaders(),
+                        });
+
+                        if (response.status === 401) {
+                            this.handleUnauthorized();
+                            return;
+                        }
+
+                        const payload = this.parseApiResponse(await response.json());
+                        if (response.ok && payload.code === 0) {
+                            const action = direction === 'outgoing' ? 'Transfer cancelled.' : 'Transfer removed.';
+                            this.directTransferSuccess = payload?.msg || action;
+                            await this.refreshDirectTransferLists();
+                        } else {
+                            this.directTransferError = payload?.msg || 'Failed to remove transfer.';
+                        }
+                    } catch (e) {
+                        this.directTransferError = 'Failed to remove transfer: ' + e.message;
                     }
                 },
 


### PR DESCRIPTION
## Summary
- add a disk-backed direct transfer store for peer-to-peer file sending and wire it into the API router
- expose endpoints to send, list, download, and cancel direct transfers with robust error handling
- refresh the web UI with a direct transfer modal, recipient loading, and client-side actions for sending and managing transfers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d610b3ab7c8327a0878928f5746779